### PR TITLE
Add book icon with docs link to title header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 ## v1.2.0 (WIP)
 
+- Adds book icon with documentation link. (#2)
+
 - Added Markdown linting via `remark-lint`. (!94)
 
 - Added Wharf web version to the sidebar menu, together with other build info

--- a/src/app/nav/nav.component.html
+++ b/src/app/nav/nav.component.html
@@ -2,7 +2,10 @@
   <div>
     <div id="logo">
       <a href="#">
-        <h3>WHARF</h3>
+        <h3>
+          WHARF
+          <a class="docs-link" href="https://iver-wharf.github.io/#/">📘</a>
+        </h3>
       </a>
 
       <button class="version-button" type="button" pButton (click)="versionPanel.toggle($event)">

--- a/src/scss/nav.component.scss
+++ b/src/scss/nav.component.scss
@@ -50,6 +50,10 @@ nav {
         overflow-wrap: break-word;
       }
     }
+    .docs-link {
+      font-size: 1rem;
+      margin: 0.4rem;
+    }
   }
 
   .p-menu {


### PR DESCRIPTION
## Adds docs link to nav bar title 

This adds a book icon with a link to the docs page.

### Before
![image](https://user-images.githubusercontent.com/4283527/117645275-b11cf400-b18a-11eb-9d97-fe6e9646eec0.png)

### After 
![image](https://user-images.githubusercontent.com/4283527/117645089-774bed80-b18a-11eb-898b-4f485ac21a83.png)
