### PR TITLE
Defend from error on invalid URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 ## v1.3.1 (WIP)
 
-- Adds a URL validator to the add project/provider forms. (#6)
+- Added a URL validator to the add project/provider forms. (#6)
 
 - Added newly generated code for each Swagger-based API clients inside
   `projects` directory inside repository: (#34)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 ## v1.3.1 (WIP)
 
+- Adds a URL validator to the add project/provider forms. (#6)
+
 - Added newly generated code for each Swagger-based API clients inside
   `projects` directory inside repository: (#34)
 

--- a/src/app/projects/project-list/project-list-item.component.ts
+++ b/src/app/projects/project-list/project-list-item.component.ts
@@ -29,9 +29,13 @@ export class ProjectListItemComponent implements OnChanges {
 
   ngOnChanges(changes: NgChanges<ProjectListItemComponent>): void {
     if (changes.project && this.project) {
-      this.providerHostname = this.project.provider?.url
-        ? new URL(this.project.provider.url).hostname
-        : null;
+      try {
+        this.providerHostname = this.project.provider?.url
+          ? new URL(this.project.provider.url).hostname
+          : null;
+      } catch (e) {
+        this.providerHostname = null;
+      }
     }
   }
 

--- a/src/app/projects/project-list/project-list-item.component.ts
+++ b/src/app/projects/project-list/project-list-item.component.ts
@@ -28,13 +28,11 @@ export class ProjectListItemComponent implements OnChanges {
   ) { }
 
   ngOnChanges(changes: NgChanges<ProjectListItemComponent>): void {
-    if (changes.project && this.project) {
+    if (changes.project && this.project?.provider?.url) {
       try {
-        this.providerHostname = this.project.provider?.url
-          ? new URL(this.project.provider.url).hostname
-          : null;
+        this.providerHostname = new URL(this.project.provider.url).hostname;
       } catch (e) {
-        this.providerHostname = null;
+        this.providerHostname = this.project.provider.url;
       }
     }
   }

--- a/src/app/providers/provider-form/azuredevops/azuredevops-form.model.ts
+++ b/src/app/providers/provider-form/azuredevops/azuredevops-form.model.ts
@@ -1,7 +1,8 @@
 import { Validators } from '@angular/forms';
+import { invalidUrlValidator } from '../../../shared/validator-functions/invalid-url-validator.directive';
 
 export class AzureDevOpsFormModel {
-  url = ['', [Validators.required]];
+  url = ['', [Validators.required, invalidUrlValidator()]];
   token = ['', [Validators.required]];
   group = ['', [Validators.required]];
   project = [''];

--- a/src/app/providers/provider-form/azuredevops/azuredevops.component.html
+++ b/src/app/providers/provider-form/azuredevops/azuredevops.component.html
@@ -3,7 +3,7 @@
     <h5><label>URL <span class="required">*</span></label></h5>
     <span *ngIf="providerForm.get('url').validator"></span>
     <input pInputText type="text" placeholder="URL" formControlName="url" required class="form-input">
-    <p-tag *ngIf="!providerForm.controls.url.valid && providerForm.controls.url.enabled" severity="danger" value="The url '{{providerForm.controls.url.value}}' is not valid!"></p-tag>
+    <p-tag *ngIf="!providerForm.controls.url.valid && providerForm.controls.url.enabled" severity="danger" value="The url is not valid!"></p-tag>
   </div>
   <div class="form-control">
     <h5><label>Token <span class="required">*</span></label></h5>

--- a/src/app/providers/provider-form/azuredevops/azuredevops.component.html
+++ b/src/app/providers/provider-form/azuredevops/azuredevops.component.html
@@ -3,16 +3,19 @@
     <h5><label>URL <span class="required">*</span></label></h5>
     <span *ngIf="providerForm.get('url').validator"></span>
     <input pInputText type="text" placeholder="URL" formControlName="url" required class="form-input">
+    <p-tag *ngIf="!providerForm.controls.url.valid && providerForm.controls.url.enabled" severity="danger" value="The url '{{providerForm.controls.url.value}}' is not valid!"></p-tag>
   </div>
   <div class="form-control">
     <h5><label>Token <span class="required">*</span></label></h5>
     <span *ngIf="providerForm.get('token').validator"></span>
     <input pInputText type="text" placeholder="Token" formControlName="token" class="form-input">
+    <p-tag *ngIf="!providerForm.controls.token.valid && providerForm.controls.token.enabled" severity="danger" value="A token is required!"></p-tag>
   </div>
   <div class="form-control">
     <h5><label>Group <span class="required">*</span></label></h5>
     <span *ngIf="providerForm.get('group').validator" ></span>
     <input pInputText type="text" placeholder="Group" formControlName="group" class="form-input">
+    <p-tag *ngIf="!providerForm.controls.group.valid && providerForm.controls.group.enabled" severity="danger" value="A group is required!"></p-tag>
   </div>
   <div class="form-control">
     <h5><label>Project </label></h5>
@@ -22,6 +25,7 @@
     <h5><label>User <span class="required">*</span></label></h5>
     <span *ngIf="providerForm.get('user').validator"></span>
     <input pInputText type="text" placeholder="User" formControlName="user" class="form-input">
+    <p-tag *ngIf="!providerForm.controls.user.valid && providerForm.controls.user.enabled" severity="danger" value="A user is required!"></p-tag>
   </div>
   <div class="bottom-part">
     <p-button label="IMPORT" type="submit"[disabled]="!providerForm.valid"></p-button>

--- a/src/app/providers/provider-form/azuredevops/azuredevops.component.ts
+++ b/src/app/providers/provider-form/azuredevops/azuredevops.component.ts
@@ -1,9 +1,10 @@
 import { DefaultService as AzureService, MainImportBody } from 'import-azuredevops-client';
 import { Component } from '@angular/core';
 import { FormGroup, FormBuilder } from '@angular/forms';
-import { finalize } from 'rxjs/operators';
+import { first } from 'rxjs/operators';
 import { AzureDevOpsFormModel } from './azuredevops-form.model';
 import { ProvidersService } from '../../providers.service';
+import { GlobalErrorHandler } from '../../../shared/error/global-error-handler';
 
 @Component({
   selector: 'wh-azuredevops',
@@ -15,11 +16,14 @@ export class AzureDevOpsComponent {
   constructor(
     public azureService: AzureService,
     private formBuilder: FormBuilder,
-    private providersService: ProvidersService) {
+    private providersService: ProvidersService,
+    private globalErrorHandler: GlobalErrorHandler,
+  ) {
     this.providerForm = this.formBuilder.group(new AzureDevOpsFormModel());
   }
 
   onSubmit() {
+    this.providerForm.disable();
     const providerData: MainImportBody = {
       url: this.providerForm.value.url,
       token: this.providerForm.value.token,
@@ -29,9 +33,15 @@ export class AzureDevOpsComponent {
     };
 
     this.azureService.azuredevopsPost(providerData)
-      .pipe(
-        finalize(() => this.providersService.triggerCloseForm(this.providerForm)),
-      )
-      .subscribe();
+      .pipe(first())
+      .subscribe(() => {
+          this.providersService.triggerCloseForm(this.providerForm);
+          this.providerForm.enable();
+        },
+        err => {
+          this.providerForm.enable();
+          this.globalErrorHandler.handleError(err);
+          console.log(err);
+        });
   }
 }

--- a/src/app/providers/provider-form/azuredevops/azuredevops.component.ts
+++ b/src/app/providers/provider-form/azuredevops/azuredevops.component.ts
@@ -36,12 +36,14 @@ export class AzureDevOpsComponent {
       .pipe(first())
       .subscribe(() => {
           this.providersService.triggerCloseForm(this.providerForm);
-          this.providerForm.enable();
         },
         err => {
-          this.providerForm.enable();
           this.globalErrorHandler.handleError(err);
           console.log(err);
-        });
+        },
+        () => {
+          this.providerForm.enable();
+        },
+      );
   }
 }

--- a/src/app/providers/provider-form/github/github-form.model.ts
+++ b/src/app/providers/provider-form/github/github-form.model.ts
@@ -1,7 +1,8 @@
 import { Validators } from '@angular/forms';
+import { invalidUrlValidator } from '../../../shared/validator-functions/invalid-url-validator.directive';
 
 export class GithubFormModel {
-  url = ['', [Validators.required]];
+  url = ['', [Validators.required, invalidUrlValidator()]];
   token = ['', [Validators.required]];
   group = [''];
   project = [''];

--- a/src/app/providers/provider-form/github/github.component.html
+++ b/src/app/providers/provider-form/github/github.component.html
@@ -3,7 +3,7 @@
     <h5><label>URL <span class="required">*</span></label></h5>
     <span *ngIf="providerForm.get('url').validator"></span>
     <input pInputText type="text" placeholder="URL" formControlName="url" class="form-input">
-    <p-tag *ngIf="!providerForm.controls.url.valid && providerForm.controls.url.enabled" severity="danger" value="The url '{{providerForm.controls.url.value}}' is not valid!"></p-tag>
+    <p-tag *ngIf="!providerForm.controls.url.valid && providerForm.controls.url.enabled" severity="danger" value="The url is not valid!"></p-tag>
   </div>
   <div class="form-control">
     <h5><label>Token <span class="required">*</span></label></h5>

--- a/src/app/providers/provider-form/github/github.component.html
+++ b/src/app/providers/provider-form/github/github.component.html
@@ -3,11 +3,13 @@
     <h5><label>URL <span class="required">*</span></label></h5>
     <span *ngIf="providerForm.get('url').validator"></span>
     <input pInputText type="text" placeholder="URL" formControlName="url" class="form-input">
+    <p-tag *ngIf="!providerForm.controls.url.valid && providerForm.controls.url.enabled" severity="danger" value="The url '{{providerForm.controls.url.value}}' is not valid!"></p-tag>
   </div>
   <div class="form-control">
     <h5><label>Token <span class="required">*</span></label></h5>
     <span *ngIf="providerForm.get('token').validator"></span>
     <input pInputText type="text" placeholder="Token" formControlName="token" class="form-input">
+    <p-tag *ngIf="!providerForm.controls.token.valid && providerForm.controls.token.enabled" severity="danger" value="A token is required!"></p-tag>
   </div>
   <div class="form-control">
     <h5><label>Group</label></h5>

--- a/src/app/providers/provider-form/github/github.component.ts
+++ b/src/app/providers/provider-form/github/github.component.ts
@@ -36,12 +36,13 @@ export class GithubComponent {
       .subscribe(
         success => {
           this.providersService.triggerCloseForm(this.providerForm);
-          this.providerForm.enable();
         },
         err => {
-          this.providerForm.enable();
           this.globalErrorHandler.handleError(err);
           console.log(err);
+        },
+        () => {
+          this.providerForm.enable();
         },
       );
   }

--- a/src/app/providers/provider-form/github/github.component.ts
+++ b/src/app/providers/provider-form/github/github.component.ts
@@ -18,7 +18,8 @@ export class GithubComponent {
     public gitHubService: GitHubService,
     private formBuilder: FormBuilder,
     private providersService: ProvidersService,
-    private globalErrorHandler: GlobalErrorHandler) {
+    private globalErrorHandler: GlobalErrorHandler,
+  ) {
     this.providerForm = this.formBuilder.group(new GithubFormModel());
   }
 
@@ -38,9 +39,9 @@ export class GithubComponent {
           this.providerForm.enable();
         },
         err => {
+          this.providerForm.enable();
           this.globalErrorHandler.handleError(err);
           console.log(err);
-          this.providerForm.enable();
         },
       );
   }

--- a/src/app/providers/provider-form/gitlab/gitlab-form.model.ts
+++ b/src/app/providers/provider-form/gitlab/gitlab-form.model.ts
@@ -1,7 +1,8 @@
 import { Validators } from '@angular/forms';
+import { invalidUrlValidator } from '../../../shared/validator-functions/invalid-url-validator.directive';
 
 export class GitlabFormModel {
-  url = ['', [Validators.required]];
+  url = ['', [Validators.required, invalidUrlValidator()]];
   token = ['', [Validators.required]];
   group = [''];
   project = [''];

--- a/src/app/providers/provider-form/gitlab/gitlab.component.html
+++ b/src/app/providers/provider-form/gitlab/gitlab.component.html
@@ -3,11 +3,13 @@
     <h5><label>URL <span class="required">*</span></label></h5>
     <span *ngIf="providerForm.get('url').validator"></span>
     <input pInputText type="text" placeholder="URL" formControlName="url" class="form-input">
+    <p-tag *ngIf="!providerForm.controls.url.valid && providerForm.controls.url.enabled" severity="danger" value="The url '{{providerForm.controls.url.value}}' is not valid!"></p-tag>
   </div>
   <div class="form-control">
     <h5><label>Token <span class="required">*</span></label></h5>
     <span *ngIf="providerForm.get('token').validator"></span>
     <input pInputText type="text" placeholder="Token" formControlName="token" class="form-input">
+    <p-tag *ngIf="!providerForm.controls.token.valid && providerForm.controls.token.enabled" severity="danger" value="A token is required!"></p-tag>
   </div>
   <div class="form-control">
     <h5><label>Group </label></h5>

--- a/src/app/providers/provider-form/gitlab/gitlab.component.html
+++ b/src/app/providers/provider-form/gitlab/gitlab.component.html
@@ -3,7 +3,7 @@
     <h5><label>URL <span class="required">*</span></label></h5>
     <span *ngIf="providerForm.get('url').validator"></span>
     <input pInputText type="text" placeholder="URL" formControlName="url" class="form-input">
-    <p-tag *ngIf="!providerForm.controls.url.valid && providerForm.controls.url.enabled" severity="danger" value="The url '{{providerForm.controls.url.value}}' is not valid!"></p-tag>
+    <p-tag *ngIf="!providerForm.controls.url.valid && providerForm.controls.url.enabled" severity="danger" value="The url is not valid!"></p-tag>
   </div>
   <div class="form-control">
     <h5><label>Token <span class="required">*</span></label></h5>

--- a/src/app/providers/provider-form/gitlab/gitlab.component.ts
+++ b/src/app/providers/provider-form/gitlab/gitlab.component.ts
@@ -36,13 +36,15 @@ export class GitlabComponent {
       .pipe(first())
       .subscribe(() => {
           this.providersService.triggerCloseForm(this.providerForm);
-          this.providerForm.enable();
         },
         err => {
-          this.providerForm.enable();
           this.globalErrorHandler.handleError(err);
           console.log(err);
-        });
+        },
+        () => {
+          this.providerForm.enable();
+        },
+      );
   }
 }
 

--- a/src/app/providers/providers.module.ts
+++ b/src/app/providers/providers.module.ts
@@ -13,6 +13,7 @@ import { AzureDevOpsComponent } from './provider-form/azuredevops/azuredevops.co
 import { MenuModule } from 'primeng/menu';
 import { InputTextModule } from 'primeng/inputtext';
 import { ConfiguredAzureDevOpsModule, ConfiguredGitHubApiModule, ConfiguredGitLabApiModule } from 'projects/projects.module';
+import {TagModule} from 'primeng/tag';
 
 @NgModule({
   declarations: [
@@ -35,6 +36,7 @@ import { ConfiguredAzureDevOpsModule, ConfiguredGitHubApiModule, ConfiguredGitLa
     ConfiguredAzureDevOpsModule,
     ConfiguredGitHubApiModule,
     ConfiguredGitLabApiModule,
+    TagModule,
   ],
   providers: [],
   exports: [

--- a/src/app/providers/providers.module.ts
+++ b/src/app/providers/providers.module.ts
@@ -12,8 +12,12 @@ import { GithubComponent } from './provider-form/github/github.component';
 import { AzureDevOpsComponent } from './provider-form/azuredevops/azuredevops.component';
 import { MenuModule } from 'primeng/menu';
 import { InputTextModule } from 'primeng/inputtext';
-import { ConfiguredAzureDevOpsModule, ConfiguredGitHubApiModule, ConfiguredGitLabApiModule } from 'projects/projects.module';
-import {TagModule} from 'primeng/tag';
+import {
+  ConfiguredAzureDevOpsModule,
+  ConfiguredGitHubApiModule,
+  ConfiguredGitLabApiModule,
+} from 'projects/projects.module';
+import { TagModule } from 'primeng/tag';
 
 @NgModule({
   declarations: [
@@ -26,6 +30,9 @@ import {TagModule} from 'primeng/tag';
   imports: [
     ButtonModule,
     CommonModule,
+    ConfiguredAzureDevOpsModule,
+    ConfiguredGitHubApiModule,
+    ConfiguredGitLabApiModule,
     DialogModule,
     DropdownModule,
     FormsModule,
@@ -33,9 +40,6 @@ import {TagModule} from 'primeng/tag';
     MenuModule,
     ReactiveFormsModule,
     SplitButtonModule,
-    ConfiguredAzureDevOpsModule,
-    ConfiguredGitHubApiModule,
-    ConfiguredGitLabApiModule,
     TagModule,
   ],
   providers: [],
@@ -43,4 +47,5 @@ import {TagModule} from 'primeng/tag';
     ProviderComponent,
   ],
 })
-export class ProvidersModule { }
+export class ProvidersModule {
+}


### PR DESCRIPTION
## Bug Fix - Invalid URLs

This fixes an issue where an invlid URL set on a project produces an error. 
~~This is solved by silencing the error that occurs when the constructor for `new URL(...)`  fails.~~
Edit:
This is solved by introducing form validation with form locking on invalid input for all the provider forms. Additionally they way URLs get processed has changed see- https://github.com/iver-wharf/wharf-web/pull/6#discussion_r636688850 - 

Example validation failed.
![image](https://user-images.githubusercontent.com/4283527/121675215-678a3680-cab3-11eb-8726-9454c13f9dd6.png)

Example validation passed-
![image](https://user-images.githubusercontent.com/4283527/121675422-aa4c0e80-cab3-11eb-9fd7-a4156ab247e4.png)
