### PR TITLE
Bind provider form to api call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	When composing new changes to this list, try to follow convention.
 
 	The WIP release shall be updated just before adding the Git tag.
-	From (WIP) to (YYYY-MM-DD), ex: (2021-02-09) for 9th of Febuary, 2021
+	From (WIP) to (YYYY-MM-DD), ex: (2021-02-09) for 9th of February, 2021
 
 	A good source on conventions can be found here:
 	https://changelog.md/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v1.2.1 (WIP)
+## v1.3.0 (WIP)
 
-- Add logic to the empty GitHub post service. This will now post form contents to the github-provider.
-- Add refresh logic for the GitHub configurations.
+- Added logic to the empty GitHub post service. This will now post form
+  contents to the github-provider. (#8)
+
+- Added refresh logic for the GitHub configurations. (#8)
 
 ## v1.2.0 (2021-05-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v1.2.1 (WIP)
+
+- Add logic to the empty GitHub post service. This will now post form contents to the github-provider.
+- Add refresh logic for the GitHub configurations.
+
 ## v1.2.0 (2021-05-28)
 
 - Added Markdown linting via `remark-lint`. (!94)

--- a/src/app/providers/provider-form/github/github-form.model.ts
+++ b/src/app/providers/provider-form/github/github-form.model.ts
@@ -5,5 +5,4 @@ export class GithubFormModel {
   token = ['', [Validators.required]];
   group = [''];
   project = [''];
-  uploadUrl = ['', [Validators.required]];
 }

--- a/src/app/providers/provider-form/github/github.component.html
+++ b/src/app/providers/provider-form/github/github.component.html
@@ -17,11 +17,6 @@
     <h5><label>Project</label></h5>
     <input pInputText type="text" placeholder="Project" formControlName="project" class="form-input">
   </div>
-  <div class="form-control">
-    <h5><label>Upload URL <span class="required">*</span></label></h5>
-    <span *ngIf="providerForm.get('uploadUrl').validator"></span>
-    <input pInputText type="text" placeholder="Upload URL" formControlName="uploadUrl" class="form-input">
-  </div>
   <div class="bottom-part">
     <p-button label="IMPORT" type="submit"[disabled]="!providerForm.valid"></p-button>
   </div>

--- a/src/app/providers/provider-form/github/github.component.ts
+++ b/src/app/providers/provider-form/github/github.component.ts
@@ -1,7 +1,10 @@
 import { Component } from '@angular/core';
 import { FormGroup, FormBuilder } from '@angular/forms';
 import { GithubFormModel } from './github-form.model';
+import { DefaultService as GitHubService } from 'import-github-client';
 import { ProvidersService } from '../../providers.service';
+import { finalize } from 'rxjs/operators';
+import { MainImport } from 'projects/import-gitlab-client/src/model/models';
 
 @Component({
   selector: 'wh-github',
@@ -11,13 +14,24 @@ export class GithubComponent {
   providerForm: FormGroup;
 
   constructor(
+    public gitHubService: GitHubService,
     private formBuilder: FormBuilder,
     private providersService: ProvidersService) {
     this.providerForm = this.formBuilder.group(new GithubFormModel());
   }
 
   onSubmit() {
-    console.warn('Not implemented');
-    this.providersService.triggerCloseForm(this.providerForm);
+    const providerData: MainImport = {
+      url: this.providerForm.value.url,
+      token: this.providerForm.value.token,
+      group: this.providerForm.value.group,
+      project: this.providerForm.value.project,
+      uploadUrl: this.providerForm.value.uploadUrl
+    };
+    this.gitHubService.githubPost(providerData)
+      .pipe(
+        finalize(() => this.providersService.triggerCloseForm(this.providerForm))
+      )
+      .subscribe();
   }
 }

--- a/src/app/providers/provider-form/github/github.component.ts
+++ b/src/app/providers/provider-form/github/github.component.ts
@@ -25,6 +25,7 @@ export class GithubComponent {
       url: this.providerForm.value.url,
       token: this.providerForm.value.token,
       group: this.providerForm.value.group,
+      project: this.providerForm.value.project,
     };
     this.gitHubService.githubPost(providerData)
       .pipe(

--- a/src/app/providers/provider-form/github/github.component.ts
+++ b/src/app/providers/provider-form/github/github.component.ts
@@ -31,7 +31,6 @@ export class GithubComponent {
       .pipe(first())
       .subscribe(
         success => this.providersService.triggerCloseForm(this.providerForm),
-        error => {/* Error gets show to screen form window does not close. */},
       );
   }
 }

--- a/src/app/providers/provider-form/github/github.component.ts
+++ b/src/app/providers/provider-form/github/github.component.ts
@@ -3,7 +3,7 @@ import { FormGroup, FormBuilder } from '@angular/forms';
 import { GithubFormModel } from './github-form.model';
 import { DefaultService as GitHubService } from 'import-github-client';
 import { ProvidersService } from '../../providers.service';
-import { finalize } from 'rxjs/operators';
+import { first } from 'rxjs/operators';
 import { MainImport } from 'projects/import-gitlab-client/src/model/models';
 
 @Component({
@@ -28,9 +28,10 @@ export class GithubComponent {
       project: this.providerForm.value.project,
     };
     this.gitHubService.githubPost(providerData)
-      .pipe(
-        finalize(() => this.providersService.triggerCloseForm(this.providerForm))
-      )
-      .subscribe();
+      .pipe(first())
+      .subscribe(
+        success => this.providersService.triggerCloseForm(this.providerForm),
+        error => {/* Error gets show to screen form window does not close. */},
+      );
   }
 }

--- a/src/app/providers/provider-form/github/github.component.ts
+++ b/src/app/providers/provider-form/github/github.component.ts
@@ -25,8 +25,6 @@ export class GithubComponent {
       url: this.providerForm.value.url,
       token: this.providerForm.value.token,
       group: this.providerForm.value.group,
-      project: this.providerForm.value.project,
-      uploadUrl: this.providerForm.value.uploadUrl
     };
     this.gitHubService.githubPost(providerData)
       .pipe(

--- a/src/app/providers/providers.module.ts
+++ b/src/app/providers/providers.module.ts
@@ -1,5 +1,6 @@
 import { SplitButtonModule } from 'primeng/splitbutton';
 import { ApiModule as GitlabImportApiModule, Configuration as GitlabImportConfiguration } from 'import-gitlab-client';
+import { ApiModule as GitHubImportApiModule, Configuration as GitHubImportConfiguration } from 'import-github-client';
 import { ApiModule as AzureImportApiModule, Configuration as AzureImportConfiguration } from 'import-azuredevops-client';
 import { DropdownModule } from 'primeng/dropdown';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
@@ -39,6 +40,16 @@ import { InputTextModule } from 'primeng/inputtext';
       providers: [{
         provide: GitlabImportConfiguration,
         useFactory: (configService: ConfigService) => configService.getGitlabImportConfig(),
+        deps: [
+          ConfigService
+        ]
+      }]
+    },
+    {
+      ngModule: GitHubImportApiModule,
+      providers: [{
+        provide: GitHubImportConfiguration,
+        useFactory: (configService: ConfigService) => configService.getGitHubImportConfig(),
         deps: [
           ConfigService
         ]

--- a/src/app/providers/providers.service.ts
+++ b/src/app/providers/providers.service.ts
@@ -23,8 +23,8 @@ export class ProvidersService {
   constructor(
     private gitlabService: GitlabService,
     private gitHubService: GitHubService,
-    private azureDevOpsService: AzureDevOpsService) {
-  }
+    private azureDevOpsService: AzureDevOpsService,
+  ) { }
 
   triggerCloseForm(providersForm: FormGroup) {
     this.formClosedSource$.next(providersForm);

--- a/src/app/providers/providers.service.ts
+++ b/src/app/providers/providers.service.ts
@@ -7,6 +7,10 @@ import {
   DefaultService as GitlabService,
 } from 'import-gitlab-client';
 import {
+  MainImport as GitHubMainImport,
+  DefaultService as GitHubService,
+} from 'import-github-client';
+import {
   MainImport as AzureDevOpsMainImport,
   DefaultService as AzureDevOpsService,
 } from 'import-azuredevops-client';
@@ -21,7 +25,9 @@ export class ProvidersService {
 
   constructor(
     private gitlabService: GitlabService,
-    private azureDevOpsService: AzureDevOpsService) { }
+    private gitHubService: GitHubService,
+    private azureDevOpsService: AzureDevOpsService) {
+  }
 
   triggerCloseForm(providersForm: FormGroup) {
     this.formClosedSource$.next(providersForm);
@@ -37,6 +43,16 @@ export class ProvidersService {
         providerId: project.provider.providerId
       };
       return this.gitlabService.gitlabPost(importData);
+    } else if (project.provider.name === ProviderType.GitHub.toLowerCase()) {
+      const importData: GitHubMainImport = {
+        url: project.provider.url,
+        tokenId: project.provider.tokenId,
+        group: project.groupName,
+        project: project.name,
+        providerId: project.provider.providerId,
+        uploadUrl: project.provider.uploadUrl,
+      };
+      return this.gitHubService.githubPost(importData);
     } else if (project.provider.name === ProviderType.AzureDevOps.toLowerCase()) {
       const importData: AzureDevOpsMainImport = {
         url: project.provider.url,

--- a/src/app/providers/providers.service.ts
+++ b/src/app/providers/providers.service.ts
@@ -3,15 +3,12 @@ import { Injectable } from '@angular/core';
 import { Subject, Observable } from 'rxjs';
 import { FormGroup } from '@angular/forms';
 import {
-  MainImport as GitlabMainImport,
   DefaultService as GitlabService,
 } from 'import-gitlab-client';
 import {
-  MainImport as GitHubMainImport,
   DefaultService as GitHubService,
 } from 'import-github-client';
 import {
-  MainImport as AzureDevOpsMainImport,
   DefaultService as AzureDevOpsService,
 } from 'import-azuredevops-client';
 import { ProviderType } from './provider-type.enum';
@@ -34,34 +31,32 @@ export class ProvidersService {
   }
 
   refreshProject(project: WharfProject): Observable<any> {
-    if (project.provider.name === ProviderType.GitLab.toLowerCase()) {
-      const importData: GitlabMainImport = {
-        url: project.provider.url,
-        tokenId: project.provider.tokenId,
-        group: project.groupName,
-        project: project.name,
-        providerId: project.provider.providerId
-      };
-      return this.gitlabService.gitlabPost(importData);
-    } else if (project.provider.name === ProviderType.GitHub.toLowerCase()) {
-      const importData: GitHubMainImport = {
-        url: project.provider.url,
-        tokenId: project.provider.tokenId,
-        group: project.groupName,
-        project: project.name,
-        providerId: project.provider.providerId,
-        uploadUrl: project.provider.uploadUrl,
-      };
-      return this.gitHubService.githubPost(importData);
-    } else if (project.provider.name === ProviderType.AzureDevOps.toLowerCase()) {
-      const importData: AzureDevOpsMainImport = {
-        url: project.provider.url,
-        tokenId: project.provider.tokenId,
-        group: project.groupName,
-        project: project.name,
-        providerId: project.provider.providerId
-      };
-      return this.azureDevOpsService.azuredevopsPost(importData);
+    switch (project.provider.name) {
+      case ProviderType.GitLab.toLowerCase():
+        return this.gitlabService.gitlabPost({
+          url: project.provider.url,
+          tokenId: project.provider.tokenId,
+          group: project.groupName,
+          project: project.name,
+          providerId: project.provider.providerId
+        });
+      case ProviderType.GitHub.toLowerCase():
+        return this.gitHubService.githubPost({
+          url: project.provider.url,
+          tokenId: project.provider.tokenId,
+          group: project.groupName,
+          project: project.name,
+          providerId: project.provider.providerId,
+          uploadUrl: project.provider.uploadUrl,
+        });
+      case ProviderType.AzureDevOps.toLowerCase():
+        return this.azureDevOpsService.azuredevopsPost({
+          url: project.provider.url,
+          tokenId: project.provider.tokenId,
+          group: project.groupName,
+          project: project.name,
+          providerId: project.provider.providerId
+        });
     }
   }
 }

--- a/src/app/shared/config/config.service.ts
+++ b/src/app/shared/config/config.service.ts
@@ -68,6 +68,12 @@ export class ConfigService {
     });
   }
 
+  getGitHubImportConfig(): GitlabConfiguration {
+    return new GitlabConfiguration({
+      basePath: upGet(upGet(this.config, 'backendUrls'), 'githubImport')
+    });
+  }
+
   getAzureDevOpsImportConfig(): AzureDevOpsConfiguration {
     return new AzureDevOpsConfiguration({
       basePath: upGet(upGet(this.config, 'backendUrls'), 'azureDevopsImport')


### PR DESCRIPTION
This is a mirror implementation of the code that binds gitlab/azuredevops to the wahrf-web interface. This uses the wharf-github-provider to import the whaf config. 

### To use-
To add the wharf-api project the Github provider from can be use in the following way.
Post to `/import/github`
```json
{
    "group": "iver-wharf",
    "project": "wharf-api",
    "token": "${GITHUB-TOKEN}",
    "url": "https://api.github.com"
} 
```
![image](https://user-images.githubusercontent.com/4283527/119624102-19193e80-be09-11eb-8bec-e188672d7be3.png)


Links to other relevant PRs:
- https://github.com/iver-wharf/wharf-provider-github/pull/10