### PR TITLE
Restyled logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Added versions of remote services to the version panel in the sidebar. (#24)
 
+- Changed styling of build logs to have different colors on timestamps and to
+  use scrolling of the body instead of scrolling a smaller container. (#29)
+
 ## v1.2.0 (2021-05-28)
 
 - Added Markdown linting via `remark-lint`. (!94)

--- a/src/app/builds/build-details/build-details.component.html
+++ b/src/app/builds/build-details/build-details.component.html
@@ -9,11 +9,15 @@
   </wh-tabview-x>
 
   <ng-template #buildDataView >
-    <div id=console-log>
+    <div id="console-log">
       <div>
-        <p *ngFor="let log of this.logEvents">
-          [{{log.timestamp | whDate}}] - {{log.message}}
-        </p>
+        <span class="no-logs" *ngIf="logEvents.length === 0">
+          // No logs are here to be seen yet. But they might arrive soon!
+        </span>
+        <pre class="logline"
+             *ngFor="let log of logEvents"
+          ><span class="timestamp">[{{log.timestamp | whDate: 'dd MMM yyyy | hh:mm'}}]</span
+          > {{log.message}}</pre>
       </div>
     </div>
   </ng-template>

--- a/src/app/builds/build-details/build-details.component.ts
+++ b/src/app/builds/build-details/build-details.component.ts
@@ -1,5 +1,5 @@
 import { ConfigService } from './../../shared/config/config.service';
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { AfterViewChecked, Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { BuildService, MainLog } from 'api-client';
 import { WharfProject } from 'src/app/models/main-project.model';
@@ -9,7 +9,7 @@ import { BuildStatus } from '../../models/build-status';
   selector: 'wh-build-details',
   templateUrl: './build-details.component.html'
 })
-export class BuildDetailsComponent implements OnInit, OnDestroy {
+export class BuildDetailsComponent implements OnInit, OnDestroy, AfterViewChecked {
   buildId: string;
   project: WharfProject;
   buildStatus?: BuildStatus;
@@ -32,6 +32,10 @@ export class BuildDetailsComponent implements OnInit, OnDestroy {
     });
   }
 
+  ngAfterViewChecked(): void {
+    this.stayScrolledToBottom();
+  }
+
   connect(): void {
     if (this.buildStatus === BuildStatus.Scheduling || this.buildStatus === BuildStatus.Running) {
       if (!this.source) {
@@ -43,8 +47,6 @@ export class BuildDetailsComponent implements OnInit, OnDestroy {
           // When it comes to SSE, the MessageEvent.data is always a string
           const data = JSON.parse(message.data);
           this.logEvents.push(data);
-          this.container = document.querySelector('#console-log > div');
-          this.container.scrollTop = this.container.scrollHeight;
         });
       }
     } else {
@@ -64,5 +66,20 @@ export class BuildDetailsComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.source?.removeEventListener('message', this.listener);
+  }
+
+  private stayScrolledToBottom(): void {
+    if (this.isScrolledToBottom()) {
+      this.scrollToBottom();
+    }
+  }
+
+  private scrollToBottom(): void {
+    window.scrollTo(0,document.body.scrollHeight);
+  }
+
+  private isScrolledToBottom(): boolean {
+    // The -2 is to have some margin for error
+    return (window.innerHeight + window.pageYOffset) >= document.body.scrollHeight - 2;
   }
 }

--- a/src/app/builds/build-details/build-details.component.ts
+++ b/src/app/builds/build-details/build-details.component.ts
@@ -75,7 +75,7 @@ export class BuildDetailsComponent implements OnInit, OnDestroy, AfterViewChecke
   }
 
   private scrollToBottom(): void {
-    window.scrollTo(0,document.body.scrollHeight);
+    window.scrollTo(0, document.body.scrollHeight);
   }
 
   private isScrolledToBottom(): boolean {

--- a/src/scss/build-details.component.scss
+++ b/src/scss/build-details.component.scss
@@ -7,9 +7,24 @@
   color: white;
   font-family: monospace;
   padding: 0;
+  border-radius: 0.3em;
 
   div {
+    padding: 1rem;
     min-height: 700px;
     overflow-x: auto;
+
+    .logline {
+      margin: 0.2em 0;
+    }
+
+    .timestamp {
+      color: $wharf_builds_log_timestamp_text_color;
+    }
+
+    .no-logs {
+      font-style: italic;
+      color: $wharf_builds_log_empty_text_color;
+    }
   }
 }

--- a/src/scss/build-details.component.scss
+++ b/src/scss/build-details.component.scss
@@ -9,7 +9,7 @@
   padding: 0;
 
   div {
-    height: 700px;
-    overflow: auto;
+    min-height: 700px;
+    overflow-x: auto;
   }
 }

--- a/src/scss/variables.scss
+++ b/src/scss/variables.scss
@@ -77,7 +77,11 @@ $wharf_sidenav_menu_version_details_value_color: $wharf_dirty_white;
 $wharf_sidenav_menu_version_details_background_color: $wharf_palette_primary_gunmetal_black;
 $wharf_sidenav_menu_version_remote_pending_text_color: $wharf_lighter_grey;
 $wharf_sidenav_menu_version_remote_error_text_color: $color_warn;
+
+//Builds
 $wharf_builds_description_text_color: $wharf_palette_cloud_grey;
+$wharf_builds_log_timestamp_text_color: $wharf_palette_cloud_grey;
+$wharf_builds_log_empty_text_color: $wharf_palette_cloud_grey;
 
 //Tabviews
 $wharf_tabview_default_color: $wharf_palette_cloud_grey;


### PR DESCRIPTION
This is a smaller change but something I've been annoyed by for ages.

## Changes

- Use native page scrolling in logs instead of inner div
- Changed log lines to use `<pre>` instead of `<p>` so that spaces are not condensed
- Restyled logs

## Preview

Before:

![Screenshot_2021-06-03_11-33-35](https://user-images.githubusercontent.com/2477952/120622959-92dfa680-c45f-11eb-9fe3-417ae59bc6f7.png)

After:

![Screenshot_2021-06-03_11-33-16](https://user-images.githubusercontent.com/2477952/120622954-92471000-c45f-11eb-9930-25c4f68b9643.png)

Empty scroll message looks like this:

![Screenshot_2021-06-03_11-39-20](https://user-images.githubusercontent.com/2477952/120623828-60827900-c460-11eb-8a3e-8f13319df258.png)
