### PR TITLE
Added back @angular-devkit/architect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Added versions of remote services to the version panel in the sidebar. (#24)
 
-- Changed version of Angular from v9 to v12. Nothing major for end users. (#27)
+- Changed version of Angular from v9 to v12. Nothing major for end users.
+  (#27, #32)
 
 - Changed version of PrimeNG from v11 to v12 and PrimeIcons from v2 to v4.
   The interface looks the same, but the new icons might take time to getting

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,47 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@angular-devkit/architect": {
+      "version": "0.1200.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1200.3.tgz",
+      "integrity": "sha512-CaqushsPYQ3Us7eBIuZM9/u5H6Rjvm5tUCYS7D5lr5w4QbiwC+6L4dheWEu1PuS2TyyBt6lVwgUNguOmixDb0Q==",
+      "dev": true,
+      "requires": {
+        "@angular-devkit/core": "12.0.3",
+        "rxjs": "6.6.7"
+      },
+      "dependencies": {
+        "@angular-devkit/core": {
+          "version": "12.0.3",
+          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-12.0.3.tgz",
+          "integrity": "sha512-d6E4ldHzIerzFpXXZkynluIbZZeYD+VteFLBZ77lOXAuUYuuLEiW8h4bpJOqribeJli5c1cJ/yyELYHrbiiLcw==",
+          "dev": true,
+          "requires": {
+            "ajv": "8.2.0",
+            "ajv-formats": "2.0.2",
+            "fast-json-stable-stringify": "2.1.0",
+            "magic-string": "0.25.7",
+            "rxjs": "6.6.7",
+            "source-map": "0.7.3"
+          }
+        },
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
+      }
+    },
     "@angular-devkit/build-angular": {
       "version": "12.0.2",
       "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-12.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "zone.js": "~0.11.4"
   },
   "devDependencies": {
+    "@angular-devkit/architect": "^0.1200.3",
     "@angular-devkit/build-angular": "~12.0.2",
     "@angular-eslint/builder": "12.1.0",
     "@angular-eslint/eslint-plugin": "12.1.0",


### PR DESCRIPTION
Must've been lost when updating to Angular 12 or something. It's needed for `npm run lint` / `ng lint` to run.

Without changes:

```console
$ npx ng run lint
An unhandled exception occurred: Cannot find module '@angular-devkit/architect'
Require stack:
- /home/kalle/dev/wharf/wharf-web/node_modules/@angular-eslint/builder/dist/index.js
- /home/kalle/dev/wharf/wharf-web/node_modules/@angular/cli/node_modules/@angular-devkit/architect/node/node-modules-architect-host.js
- /home/kalle/dev/wharf/wharf-web/node_modules/@angular/cli/node_modules/@angular-devkit/architect/node/index.js
- /home/kalle/dev/wharf/wharf-web/node_modules/@angular/cli/models/architect-command.js
- /home/kalle/dev/wharf/wharf-web/node_modules/@angular/cli/commands/lint-impl.js
- /home/kalle/dev/wharf/wharf-web/node_modules/@angular-devkit/schematics/tools/export-ref.js
- /home/kalle/dev/wharf/wharf-web/node_modules/@angular-devkit/schematics/tools/index.js
- /home/kalle/dev/wharf/wharf-web/node_modules/@angular/cli/utilities/json-schema.js
- /home/kalle/dev/wharf/wharf-web/node_modules/@angular/cli/models/command-runner.js
- /home/kalle/dev/wharf/wharf-web/node_modules/@angular/cli/lib/cli/index.js
- /home/kalle/dev/wharf/wharf-web/node_modules/@angular/cli/lib/init.js
- /home/kalle/dev/wharf/wharf-web/node_modules/@angular/cli/bin/ng
See "/tmp/ng-ZNVkUA/angular-errors.log" for further details.
```

With changes:

```console
$ npx ng run lint
Linting "wharf"...

All files pass linting.
```