### PR TITLE
OnHold: Feature/route additional meta info

### DIFF
--- a/src/app/projects/project-details/project-details.component.html
+++ b/src/app/projects/project-details/project-details.component.html
@@ -29,7 +29,7 @@
       </div>
     </div>
     <div class="project-page-body">
-      <wh-tabview-x *ngIf="project.buildHistory" [(activeIndex)]="activeTabIndex" (activeIndexChange)="updateQueryParamsWithTabIndex($event)">
+      <wh-tabview-x *ngIf="project.buildHistory" [(activeIndex)]="activeTabIndex" (activeIndexChange)="tabviewTrackerService.updateQueryParamsWithTabIndex($event)">
         <wh-tabpanel-x header="Builds">
           <ng-template pTemplate="side-header-override">
             <p-splitButton *ngIf="project.actions"

--- a/src/app/projects/project-details/project-details.component.html
+++ b/src/app/projects/project-details/project-details.component.html
@@ -29,36 +29,39 @@
       </div>
     </div>
     <div class="project-page-body">
-      <wh-tabview-x *ngIf="project.buildHistory">
-        <wh-tabpanel-x header="Builds">
-          <ng-template pTemplate="side-header-override">
-            <p-splitButton *ngIf="project.actions"
-              class="button-container"
-              label="{{projectUtilsService.runAllActionName}}"
-              [model]="projectUtilsService.getActionsMenuItems(project)"
-              (onClick)="projectUtilsService.openActions(projectUtilsService.runAllActionName,project)">
-            </p-splitButton>
-          </ng-template>
-          <ng-container *ngTemplateOutlet="buildsHistory"></ng-container>
-        </wh-tabpanel-x>
-        <wh-tabpanel-x>
-          <ng-template pTemplate="header">
-            <span class="p-tabview-title">Configuration <i class="pi pi-exclamation-circle" *ngIf="!project.buildDefinition"></i></span>
-          </ng-template>
-          <ng-container *ngTemplateOutlet="configuration"></ng-container>
-          <ng-template pTemplate="side-header-override">
-            <wh-project-refresh-button
-              #refreshButton
-              (refreshed)="reloadProject()"
-              [project]="project"
+      <a class="router-link-invisible" [routerLink]="[]" [queryParams]="{tab: activeTab}">
+        <wh-tabview-x *ngIf="project.buildHistory" [(activeIndex)]="activeTab">
+          <wh-tabpanel-x header="Builds">
+            <ng-template pTemplate="side-header-override">
+              <p-splitButton *ngIf="project.actions"
+                             class="button-container"
+                             label="{{projectUtilsService.runAllActionName}}"
+                             [model]="projectUtilsService.getActionsMenuItems(project)"
+                             (onClick)="projectUtilsService.openActions(projectUtilsService.runAllActionName,project)">
+              </p-splitButton>
+            </ng-template>
+            <ng-container *ngTemplateOutlet="buildsHistory"></ng-container>
+          </wh-tabpanel-x>
+          <wh-tabpanel-x>
+            <ng-template pTemplate="header">
+              <span class="p-tabview-title">Configuration <i class="pi pi-exclamation-circle"
+                                                             *ngIf="!project.buildDefinition"></i></span>
+            </ng-template>
+            <ng-container *ngTemplateOutlet="configuration"></ng-container>
+            <ng-template pTemplate="side-header-override">
+              <wh-project-refresh-button
+                #refreshButton
+                (refreshed)="reloadProject()"
+                [project]="project"
               ></wh-project-refresh-button>
-          </ng-template>
-        </wh-tabpanel-x>
-        <wh-tabpanel-x header="Schedule" disabled="true" tooltip='This feature has not yet been implemented.
+            </ng-template>
+          </wh-tabpanel-x>
+          <wh-tabpanel-x header="Schedule" disabled="true" tooltip='This feature has not yet been implemented.
         Stay tuned!' tooltipPosition="top">
-          <ng-container *ngTemplateOutlet="schedule"></ng-container>
-        </wh-tabpanel-x>
-      </wh-tabview-x>
+            <ng-container *ngTemplateOutlet="schedule"></ng-container>
+          </wh-tabpanel-x>
+        </wh-tabview-x>
+      </a>
     </div>
   </div>
 
@@ -67,7 +70,8 @@
   </ng-template>
 
   <ng-template #configuration>
-    <wh-project-details-configuration [project]="project" (wantToRefresh)="refreshProject()"></wh-project-details-configuration>
+    <wh-project-details-configuration [project]="project"
+                                      (wantToRefresh)="refreshProject()"></wh-project-details-configuration>
   </ng-template>
 
   <ng-template #schedule>

--- a/src/app/projects/project-details/project-details.component.html
+++ b/src/app/projects/project-details/project-details.component.html
@@ -29,39 +29,37 @@
       </div>
     </div>
     <div class="project-page-body">
-      <a class="router-link-invisible" [routerLink]="[]" [queryParams]="{tab: activeTab}">
-        <wh-tabview-x *ngIf="project.buildHistory" [(activeIndex)]="activeTab">
-          <wh-tabpanel-x header="Builds">
-            <ng-template pTemplate="side-header-override">
-              <p-splitButton *ngIf="project.actions"
-                             class="button-container"
-                             label="{{projectUtilsService.runAllActionName}}"
-                             [model]="projectUtilsService.getActionsMenuItems(project)"
-                             (onClick)="projectUtilsService.openActions(projectUtilsService.runAllActionName,project)">
-              </p-splitButton>
-            </ng-template>
-            <ng-container *ngTemplateOutlet="buildsHistory"></ng-container>
-          </wh-tabpanel-x>
-          <wh-tabpanel-x>
-            <ng-template pTemplate="header">
+      <wh-tabview-x *ngIf="project.buildHistory" [(activeIndex)]="activeTabIndex" (activeIndexChange)="updateQueryParamsWithTabIndex($event)">
+        <wh-tabpanel-x header="Builds">
+          <ng-template pTemplate="side-header-override">
+            <p-splitButton *ngIf="project.actions"
+                           class="button-container"
+                           label="{{projectUtilsService.runAllActionName}}"
+                           [model]="projectUtilsService.getActionsMenuItems(project)"
+                           (onClick)="projectUtilsService.openActions(projectUtilsService.runAllActionName,project)">
+            </p-splitButton>
+          </ng-template>
+          <ng-container *ngTemplateOutlet="buildsHistory"></ng-container>
+        </wh-tabpanel-x>
+        <wh-tabpanel-x>
+          <ng-template pTemplate="header">
               <span class="p-tabview-title">Configuration <i class="pi pi-exclamation-circle"
                                                              *ngIf="!project.buildDefinition"></i></span>
-            </ng-template>
-            <ng-container *ngTemplateOutlet="configuration"></ng-container>
-            <ng-template pTemplate="side-header-override">
-              <wh-project-refresh-button
-                #refreshButton
-                (refreshed)="reloadProject()"
-                [project]="project"
-              ></wh-project-refresh-button>
-            </ng-template>
-          </wh-tabpanel-x>
-          <wh-tabpanel-x header="Schedule" disabled="true" tooltip='This feature has not yet been implemented.
+          </ng-template>
+          <ng-container *ngTemplateOutlet="configuration"></ng-container>
+          <ng-template pTemplate="side-header-override">
+            <wh-project-refresh-button
+              #refreshButton
+              (refreshed)="reloadProject()"
+              [project]="project"
+            ></wh-project-refresh-button>
+          </ng-template>
+        </wh-tabpanel-x>
+        <wh-tabpanel-x header="Schedule" disabled="true" tooltip='This feature has not yet been implemented.
         Stay tuned!' tooltipPosition="top">
-            <ng-container *ngTemplateOutlet="schedule"></ng-container>
-          </wh-tabpanel-x>
-        </wh-tabview-x>
-      </a>
+          <ng-container *ngTemplateOutlet="schedule"></ng-container>
+        </wh-tabpanel-x>
+      </wh-tabview-x>
     </div>
   </div>
 

--- a/src/app/projects/project-details/project-details.component.scss
+++ b/src/app/projects/project-details/project-details.component.scss
@@ -1,3 +1,0 @@
-.router-link-invisible {
-  all: unset !important;
-}

--- a/src/app/projects/project-details/project-details.component.scss
+++ b/src/app/projects/project-details/project-details.component.scss
@@ -1,0 +1,3 @@
+.router-link-invisible {
+  all: unset !important;
+}

--- a/src/app/projects/project-details/project-details.component.ts
+++ b/src/app/projects/project-details/project-details.component.ts
@@ -7,8 +7,9 @@ import { LocalStorageProjectsService } from '../local-storage-projects.service';
 import { NotificationService } from 'src/app/shared/notification/notification.service';
 import { ActionsModalStore } from '../actions-modal/actions-modal.service';
 import { ProjectService } from 'api-client';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { ProjectTabType } from './project-tab-types';
+import { Location } from '@angular/common';
 
 @Component({
   selector: 'wh-project-details',
@@ -20,12 +21,10 @@ export class ProjectDetailsComponent implements OnInit, AfterViewInit {
 
   project: WharfProject;
   isActionsFormVisible = false;
-  editedProjectInstance: WharfProject;
-  buildsTotalCount = 0;
   rowsCount = 10;
   destroyed$ = new Subject<void>();
 
-  public activeTab: ProjectTabType;
+  public activeTabIndex: ProjectTabType;
 
   constructor(
     public projectUtilsService: ProjectUtilsService,
@@ -33,7 +32,9 @@ export class ProjectDetailsComponent implements OnInit, AfterViewInit {
     private notificationService: NotificationService,
     private actionsModalStore: ActionsModalStore,
     private projectService: ProjectService,
+    private router: Router,
     private route: ActivatedRoute,
+    private location: Location,
   ) { }
 
   ngOnInit(): void {
@@ -41,7 +42,21 @@ export class ProjectDetailsComponent implements OnInit, AfterViewInit {
   }
 
   ngAfterViewInit(): void {
-    this.activeTab = this.route.snapshot.queryParams?.tab as ProjectTabType || ProjectTabType.BUILDS;
+    this.activeTabIndex = this.route.snapshot.queryParams?.tab as ProjectTabType || ProjectTabType.BUILDS;
+  }
+
+  public updateQueryParamsWithTabIndex(index: number): void {
+    const queryParams = {
+      tab: this.activeTabIndex,
+    };
+    const urlTree = this.router.createUrlTree(
+      [],
+      {
+        queryParams,
+        relativeTo: this.route,
+      },
+    );
+    this.location.replaceState(urlTree.toString());
   }
 
   reloadProject() {

--- a/src/app/projects/project-details/project-details.component.ts
+++ b/src/app/projects/project-details/project-details.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, OnInit, ViewChild } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { WharfProject } from 'src/app/models/main-project.model';
@@ -9,14 +9,15 @@ import { ActionsModalStore } from '../actions-modal/actions-modal.service';
 import { ProjectService } from 'api-client';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ProjectTabType } from './project-tab-types';
-import { Location } from '@angular/common';
+import { TabviewIndexTrackerService } from '../../shared/tabview-x/tabview-index-tracker.service';
 
 @Component({
   selector: 'wh-project-details',
   templateUrl: './project-details.component.html',
   styleUrls: ['./project-details.component.scss'],
+  providers: [TabviewIndexTrackerService],
 })
-export class ProjectDetailsComponent implements OnInit, AfterViewInit {
+export class ProjectDetailsComponent implements OnInit {
   @ViewChild('refreshButton') refreshButton;
 
   project: WharfProject;
@@ -32,31 +33,13 @@ export class ProjectDetailsComponent implements OnInit, AfterViewInit {
     private notificationService: NotificationService,
     private actionsModalStore: ActionsModalStore,
     private projectService: ProjectService,
-    private router: Router,
     private route: ActivatedRoute,
-    private location: Location,
+    public tabviewTrackerService: TabviewIndexTrackerService,
   ) { }
 
   ngOnInit(): void {
     this.reloadProject();
-  }
-
-  ngAfterViewInit(): void {
-    this.activeTabIndex = this.route.snapshot.queryParams?.tab as ProjectTabType || ProjectTabType.BUILDS;
-  }
-
-  public updateQueryParamsWithTabIndex(index: number): void {
-    const queryParams = {
-      tab: this.activeTabIndex,
-    };
-    const urlTree = this.router.createUrlTree(
-      [],
-      {
-        queryParams,
-        relativeTo: this.route,
-      },
-    );
-    this.location.replaceState(urlTree.toString());
+    this.activeTabIndex = this.tabviewTrackerService.getTabIndexFromQueryParams();
   }
 
   reloadProject() {

--- a/src/app/projects/project-details/project-details.component.ts
+++ b/src/app/projects/project-details/project-details.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, OnInit, ViewChild } from '@angular/core';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { WharfProject } from 'src/app/models/main-project.model';
@@ -8,12 +8,14 @@ import { NotificationService } from 'src/app/shared/notification/notification.se
 import { ActionsModalStore } from '../actions-modal/actions-modal.service';
 import { ProjectService } from 'api-client';
 import { ActivatedRoute } from '@angular/router';
+import { ProjectTabType } from './project-tab-types';
 
 @Component({
   selector: 'wh-project-details',
   templateUrl: './project-details.component.html',
+  styleUrls: ['./project-details.component.scss'],
 })
-export class ProjectDetailsComponent implements OnInit {
+export class ProjectDetailsComponent implements OnInit, AfterViewInit {
   @ViewChild('refreshButton') refreshButton;
 
   project: WharfProject;
@@ -22,6 +24,8 @@ export class ProjectDetailsComponent implements OnInit {
   buildsTotalCount = 0;
   rowsCount = 10;
   destroyed$ = new Subject<void>();
+
+  public activeTab: ProjectTabType;
 
   constructor(
     public projectUtilsService: ProjectUtilsService,
@@ -34,6 +38,10 @@ export class ProjectDetailsComponent implements OnInit {
 
   ngOnInit(): void {
     this.reloadProject();
+  }
+
+  ngAfterViewInit(): void {
+    this.activeTab = this.route.snapshot.queryParams?.tab as ProjectTabType || ProjectTabType.BUILDS;
   }
 
   reloadProject() {
@@ -68,4 +76,5 @@ export class ProjectDetailsComponent implements OnInit {
     }
     selection.removeAllRanges();
   }
+
 }

--- a/src/app/projects/project-details/project-tab-types.ts
+++ b/src/app/projects/project-details/project-tab-types.ts
@@ -1,0 +1,5 @@
+export enum ProjectTabType {
+  BUILDS,
+  CONFIGURATION,
+  SCHEDULE,
+}

--- a/src/app/projects/project-list/project-list.component.html
+++ b/src/app/projects/project-list/project-list.component.html
@@ -1,5 +1,5 @@
 <section>
-  <wh-tabview-x [(activeIndex)]="activeTabIndex">
+  <wh-tabview-x [(activeIndex)]="activeTabIndex" (activeIndexChange)="updateQueryParamsWithTabIndex($event)">
     <wh-tabpanel-x header="All Projects">
       <ng-container *ngTemplateOutlet="template;context:{projects:
         this.projects}"></ng-container>

--- a/src/app/projects/project-list/project-list.component.html
+++ b/src/app/projects/project-list/project-list.component.html
@@ -1,5 +1,5 @@
 <section>
-  <wh-tabview-x [(activeIndex)]="activeTabIndex" (activeIndexChange)="updateQueryParamsWithTabIndex($event)">
+  <wh-tabview-x [(activeIndex)]="activeTabIndex" (activeIndexChange)="tabviewTrackerService.updateQueryParamsWithTabIndex($event)">
     <wh-tabpanel-x header="All Projects">
       <ng-container *ngTemplateOutlet="template;context:{projects:
         this.projects}"></ng-container>

--- a/src/app/projects/project-list/project-list.component.ts
+++ b/src/app/projects/project-list/project-list.component.ts
@@ -1,5 +1,5 @@
-import { AfterViewInit, Component, OnInit, QueryList, ViewChildren } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { Component, OnInit, QueryList, ViewChildren } from '@angular/core';
+import { Router } from '@angular/router';
 import { ProjectService } from 'api-client';
 import { SelectItem } from 'primeng/api/selectitem';
 import { Table } from 'primeng/table';
@@ -10,14 +10,15 @@ import { ProvidersService } from 'src/app/providers/providers.service';
 import { ActionsModalStore } from '../actions-modal/actions-modal.service';
 import { ProjectRefreshedEvent } from '../project-refresh';
 import { LocalStorageProjectsService } from './../local-storage-projects.service';
-import { Location } from '@angular/common';
+import { TabviewIndexTrackerService } from '../../shared/tabview-x/tabview-index-tracker.service';
 
 @Component({
   selector: 'wh-project-list',
   templateUrl: './project-list.component.html',
   styleUrls: ['./project-list.component.scss'],
+  providers: [TabviewIndexTrackerService],
 })
-export class ProjectListComponent implements OnInit, AfterViewInit {
+export class ProjectListComponent implements OnInit {
   // Need ViewChildren instead of ViewChild because the ng-container actually
   // creates two data tables that it switches between.
   @ViewChildren(Table) dts: QueryList<Table>;
@@ -38,8 +39,7 @@ export class ProjectListComponent implements OnInit, AfterViewInit {
     private providersService: ProvidersService,
     private actionsModalStore: ActionsModalStore,
     private router: Router,
-    private route: ActivatedRoute,
-    private location: Location,
+    public tabviewTrackerService: TabviewIndexTrackerService,
   ) { }
 
   ngOnInit(): void {
@@ -47,24 +47,8 @@ export class ProjectListComponent implements OnInit, AfterViewInit {
     this.loadProjects();
     this.providersService.formClosed$.pipe(takeUntil(this.destroyed$)).subscribe(() => this.loadProjects());
     this.actionsModalStore.isVisible$.pipe(takeUntil(this.destroyed$)).subscribe(x => this.isActionsFormVisible = x);
-    this.activeTabIndex = this.route.snapshot.queryParams?.tab || 0;
-  }
-
-  ngAfterViewInit(): void {
-  }
-
-  public updateQueryParamsWithTabIndex(index: number): void {
-    const queryParams = {
-      tab: this.activeTabIndex,
-    };
-    const urlTree = this.router.createUrlTree(
-      [],
-      {
-        queryParams,
-        relativeTo: this.route,
-      },
-    );
-    this.location.replaceState(urlTree.toString());
+    //this.activeTabIndex = this.route.snapshot.queryParams?.tab || 0;
+    this.activeTabIndex = this.tabviewTrackerService.getTabIndexFromQueryParams();
   }
 
   onSearchKeyUp(event: KeyboardEvent) {

--- a/src/app/shared/tabview-x/tabview-index-tracker.service.spec.ts
+++ b/src/app/shared/tabview-x/tabview-index-tracker.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { TabviewIndexTrackerService } from './tabview-index-tracker.service';
+
+describe('TabviewIndexTrackerService', () => {
+  let service: TabviewIndexTrackerService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(TabviewIndexTrackerService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/shared/tabview-x/tabview-index-tracker.service.ts
+++ b/src/app/shared/tabview-x/tabview-index-tracker.service.ts
@@ -1,0 +1,50 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Location } from '@angular/common';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class TabviewIndexTrackerService {
+
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  private readonly FIRST_TAB = 0;
+
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  private readonly DEFAULT_QUERY_PARAM_KEY = 'tab';
+
+  constructor(
+    private router: Router,
+    private route: ActivatedRoute,
+    private location: Location,
+  ) {
+  }
+
+  /**
+   * Get the tabindex from the queryParams. if not found return index 0.
+   *
+   * @param paramKey defaults to 'tab'.
+   */
+  public getTabIndexFromQueryParams(paramKey = this.DEFAULT_QUERY_PARAM_KEY): number {
+    return +this.route.snapshot.queryParamMap.get(paramKey) || this.FIRST_TAB;
+  }
+
+  /**
+   * Updates the current set location with the tab index that has been requested.
+   *
+   * @param index the tab index requested.
+   */
+  public updateQueryParamsWithTabIndex(index: number, paramKey = this.DEFAULT_QUERY_PARAM_KEY): void {
+    const queryParams = {};
+    queryParams[paramKey] = index;
+    const urlTree = this.router.createUrlTree(
+      [],
+      {
+        queryParams,
+        queryParamsHandling: 'merge',
+        relativeTo: this.route,
+      },
+    );
+    this.location.replaceState(urlTree.toString());
+  }
+}


### PR DESCRIPTION
### On Hold

This is under discussion and may be dropped infavour of a better solution that is to be decided.

### Description

This adds the tab key to the query params. Tab indicated the index number of the active tab. The serivce that implements this key can also take another key instead of the default 'tab' if multiple tabviews are used on the same page.

This uses a bit more code to acomplish the goal than i had hoped but it seems to be the best solution i can come up with. 
I have also tried using css to style an `<a [routerLink]="[]" queryParams="{tab: activeTabIndex]" ...` this however seemed to cause interference issues with the other inner routers used for ids in ex projects.

Clicking a tab add the queryparams to the location. Loading either the projects list or details with the 'tab' queryparam set to a valid number will cause the correct tab to loadup as first view.
![image](https://user-images.githubusercontent.com/4283527/122212350-0645d700-cea8-11eb-9af9-04ab9ad0e6d9.png)
