### PR TITLE
Release v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v1.3.1 (WIP)
+## v1.3.1 (2021-06-17)
 
 - Added missing file
   `src/app/shared/validator-functions/invalid-url-validator.directive.ts`


### PR DESCRIPTION
The bugfix from #35 is the most crucial thing in this release.

## Changes


- Added a URL validator to the add project/provider forms. (#6)

- Added newly generated code for each Swagger-based API clients inside `projects` directory inside repository: (#34)
  - `api-client`: v4.1.0
  - `import-github-client`: v2.0.0-rc
  - `import-gitlab-client`: v1.2.0-rc
  - `import-azuredevops-client`: v1.2.0-rc

  Cleaned up old files, where some collided on case-insensitive file systems, such as `mainAzureDevOpsPrResource.ts` vs `mainAzureDevOpsPRResource.ts`.

- Fixed provider APIs getting main API's config, leading to all provider API requests pointing to wrong base URL. (#35)