### PR TITLE
Updated Docker images in Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v1.3.2 (WIP)
+
+- Changed version of nginx base image in Dockerfile from 1.19.10 to 1.21.0 and
+  node build image from 14.17.0 to 14.17.1. The nginx base image is more
+  of importance as Clair in Quay.io noticed a HIGH vulnerability in it:
+  <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3517> (#43)
+
 ## v1.3.1 (2021-07-02)
 
 - Added missing file

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.17.0-alpine3.11 AS build
+FROM node:14.17.1-alpine3.11 AS build
 
 # Set working directory
 WORKDIR /usr/src/app
@@ -27,7 +27,7 @@ RUN deploy/update-typescript-environments.sh src/environments/environment.prod.t
     && npm run build-clients \
     && npm run build-prod
 
-FROM nginx:1.19.10-alpine
+FROM nginx:1.21.0-alpine
 COPY --from=build /usr/src/app/dist/wharf /usr/share/nginx/html
 COPY ./deploy/nginx.conf /etc/nginx/conf.d/default.conf
 


### PR DESCRIPTION
New nginx and new node.js versions.

We got a warning about CVE on our latest build (v1.3.1): https://quay.io/repository/iver-wharf/wharf-web https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3517