### PR TITLE
Updated nginx Docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,20 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v1.3.3 (WIP)
+
+- Security fix by changing version of nginx base image in Dockerfile from
+  1.21.0-alpine to 1.21.1-alpine. Update in v1.3.2 was meant to resolve this
+  but didn't, and have now been confirmed to be fixed by using the
+  1.21.1-alpine image tag:
+  <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3517> (#49)
+
 ## v1.3.2 (2021-07-12)
 
-- Changed version of nginx base image in Dockerfile from 1.19.10 to 1.21.0 and
-  node build image from 14.17.0 to 14.17.1. The nginx base image is more
-  of importance as Clair in Quay.io noticed a HIGH vulnerability in it:
-  <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3517> (#43)
+- Changed version of nginx base image in Dockerfile: (#43)
+
+  - `nginx` from 1.19.10 to 1.21.0.
+  - `node` from 14.17.0 to 14.17.1.
 
 - Changed version of numerous packages: (#45)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN deploy/update-typescript-environments.sh src/environments/environment.prod.t
     && npm run build-clients \
     && npm run build-prod
 
-FROM nginx:1.21.0-alpine
+FROM nginx:1.21.1-alpine
 COPY --from=build /usr/src/app/dist/wharf /usr/share/nginx/html
 COPY ./deploy/nginx.conf /etc/nginx/conf.d/default.conf
 


### PR DESCRIPTION
## Summary

There was a security vulnerability that I tried to fix in #43, but the `nginx:1.21.0-alpine` image does not seem to have the version of `libxml` that has the fix, and so quay.io sent a warning again about the same issue.

The vulnerability in question is [CVE-2021-3517](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3517), which was fixed in libxml2 v2.9.10-r7, while the current nginx image uses libxml2 v2.9.10-r6.

```console
$ podman run --rm -it nginx:1.21.0-alpine apk list | grep libxml2
libxml2-2.9.10-r6 x86_64 {libxml2} (MIT) [installed]

$ podman run --rm -it nginx:1.21.1-alpine apk list | grep libxml2
libxml2-2.9.12-r1 x86_64 {libxml2} (MIT) [installed]
```

## Motivation

The mentioned CVE is measured as a HIGH vulnerability.

To be real, this does probably not affect us, as we're only hosting static files with nginx. But "better safe than sorry"
