### PR TITLE
Release v1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v1.3.3 (2021-07-12)
+## v1.3.3 (2021-07-13)
 
 - Security fix by changing version of nginx base image in Dockerfile from
   1.21.0-alpine to 1.21.1-alpine. Update in v1.3.2 was meant to resolve this

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v1.3.3 (WIP)
+## v1.3.3 (2021-07-12)
 
 - Security fix by changing version of nginx base image in Dockerfile from
   1.21.0-alpine to 1.21.1-alpine. Update in v1.3.2 was meant to resolve this


### PR DESCRIPTION
- \[x] I've updated the `(WIP)` tag to today's date in `CHANGELOG.md`
- \[x] I've added the `release` label to this PR

## Changes

- Security fix by changing version of nginx base image in Dockerfile from 1.21.0-alpine to 1.21.1-alpine. Update in v1.3.2 was meant to resolve this but didn't, and have now been confirmed to be fixed by using the 1.21.1-alpine image tag: <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3517> (#49)

## Actions after merge

Follow the step-by-step guide found here:
<https://iver-wharf.github.io/#/development/releasing-a-new-version?id=merging-a-release-pr>
