### PR TITLE
Added dynamic & descriptive titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v1.4.0 (WIP)
+
+- Changed tab title to be descriptive, changing based on what view you're in.
+  Previously it was just `wharf` no matter the view. (#59)
+
 ## v1.3.3 (2021-07-13)
 
 - Security fix by changing version of nginx base image in Dockerfile from

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Wharf Angular frontend
 
-[![Codacy Badge](https://app.codacy.com/project/badge/Grade/89402a769e2d4b70ba15ff29992ae6ed)](https://www.codacy.com/gh/iver-wharf/wharf-web/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=iver-wharf/wharf-web&amp;utm_campaign=Badge_Grade)
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/89402a769e2d4b70ba15ff29992ae6ed)](https://www.codacy.com/gh/iver-wharf/wharf-web/dashboard?utm_source=github.com\&utm_medium=referral\&utm_content=iver-wharf/wharf-web\&utm_campaign=Badge_Grade)
 
 ![Wharf web screenshot](docs/screenshot.jpg)
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,7 +2,7 @@ import { ProvidersModule } from './providers/providers.module';
 import { BuildsModule } from './builds/builds.module';
 import { DropdownModule } from 'primeng/dropdown';
 import { ProjectsModule } from './projects/projects.module';
-import { BrowserModule } from '@angular/platform-browser';
+import { BrowserModule, Title } from '@angular/platform-browser';
 import { NgModule, APP_INITIALIZER } from '@angular/core';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -44,6 +44,7 @@ import { NavModule } from './nav/nav.module';
       multi: true,
     },
     SyntaxHighlightService,
+    Title,
   ],
   bootstrap: [AppComponent],
 })

--- a/src/app/builds/build-details/build-details.component.html
+++ b/src/app/builds/build-details/build-details.component.html
@@ -14,7 +14,9 @@
         <span class="no-logs" *ngIf="logEvents.length === 0">
           // No logs are here to be seen yet. But they might arrive soon!
         </span>
-        <pre class="logline" *ngFor="let log of logEvents"><span class="timestamp">[{{log.timestamp | whDate: 'dd MMM yyyy | hh:mm'}}]</span
+        <pre class="logline"
+             *ngFor="let log of logEvents"
+          ><span class="timestamp">[{{log.timestamp | whDate: 'dd MMM yyyy | hh:mm'}}]</span
           > {{log.message}}</pre>
       </div>
     </div>

--- a/src/app/builds/build-details/build-details.component.html
+++ b/src/app/builds/build-details/build-details.component.html
@@ -1,5 +1,5 @@
 <section class="projects-container">
-  <wh-tabview-x>
+  <wh-tabview-x [(activeIndex)]="activeTabIndex" (onChange)="onTabChanged()">
     <wh-tabpanel-x id="build-logs" header="Logs">
       <ng-container *ngTemplateOutlet="buildDataView"></ng-container>
     </wh-tabpanel-x>
@@ -8,20 +8,18 @@
     </wh-tabpanel-x>
   </wh-tabview-x>
 
-  <ng-template #buildDataView >
+  <ng-template #buildDataView>
     <div id="console-log">
       <div>
         <span class="no-logs" *ngIf="logEvents.length === 0">
           // No logs are here to be seen yet. But they might arrive soon!
         </span>
-        <pre class="logline"
-             *ngFor="let log of logEvents"
-          ><span class="timestamp">[{{log.timestamp | whDate: 'dd MMM yyyy | hh:mm'}}]</span
+        <pre class="logline" *ngFor="let log of logEvents"><span class="timestamp">[{{log.timestamp | whDate: 'dd MMM yyyy | hh:mm'}}]</span
           > {{log.message}}</pre>
       </div>
     </div>
   </ng-template>
-  <ng-template #artifactsView >
+  <ng-template #artifactsView>
     <wh-artifacts-list [buildId]="buildId"></wh-artifacts-list>
   </ng-template>
 </section>

--- a/src/app/builds/build-details/build-details.component.ts
+++ b/src/app/builds/build-details/build-details.component.ts
@@ -4,6 +4,7 @@ import { ActivatedRoute } from '@angular/router';
 import { BuildService, MainLog } from 'api-client';
 import { WharfProject } from 'src/app/models/main-project.model';
 import { BuildStatus } from '../../models/build-status';
+import { Title } from '@angular/platform-browser';
 
 @Component({
   selector: 'wh-build-details',
@@ -18,11 +19,13 @@ export class BuildDetailsComponent implements OnInit, OnDestroy, AfterViewChecke
   listener: any = null;
   logEvents: MainLog[] = [];
   container: HTMLElement;
+  activeTabIndex = 0;
 
   constructor(
     private route: ActivatedRoute,
     private buildService: BuildService,
-    private configService: ConfigService) { }
+    private configService: ConfigService,
+    private titleService: Title) { }
 
   ngOnInit(): void {
     this.buildId = this.route.snapshot.paramMap.get('buildId');
@@ -30,6 +33,8 @@ export class BuildDetailsComponent implements OnInit, OnDestroy, AfterViewChecke
       this.buildStatus = build.statusId;
       this.connect();
     });
+
+    this.updateTitle();
   }
 
   ngAfterViewChecked(): void {
@@ -68,6 +73,10 @@ export class BuildDetailsComponent implements OnInit, OnDestroy, AfterViewChecke
     this.source?.removeEventListener('message', this.listener);
   }
 
+  onTabChanged() {
+    this.updateTitle();
+  }
+
   private stayScrolledToBottom(): void {
     if (this.isScrolledToBottom()) {
       this.scrollToBottom();
@@ -81,5 +90,16 @@ export class BuildDetailsComponent implements OnInit, OnDestroy, AfterViewChecke
   private isScrolledToBottom(): boolean {
     // The -2 is to have some margin for error
     return (window.innerHeight + window.pageYOffset) >= document.body.scrollHeight - 2;
+  }
+
+  private updateTitle() {
+    switch (this.activeTabIndex) {
+      case 0:
+        return this.titleService.setTitle('Logs - Wharf');
+      case 1:
+        return this.titleService.setTitle('Artifacts - Wharf');
+      default:
+        return this.titleService.setTitle('Wharf');
+    }
   }
 }

--- a/src/app/builds/build-details/build-details.component.ts
+++ b/src/app/builds/build-details/build-details.component.ts
@@ -1,10 +1,14 @@
 import { ConfigService } from './../../shared/config/config.service';
 import { AfterViewChecked, Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { BuildService, MainLog, ProjectService } from 'api-client';
-import { WharfProject } from 'src/app/models/main-project.model';
+import { BuildService, MainLog } from 'api-client';
 import { BuildStatus } from '../../models/build-status';
 import { Title } from '@angular/platform-browser';
+
+const enum Tabs {
+  LOGS = 0,
+  ARTIFACTS,
+}
 
 @Component({
   selector: 'wh-build-details',
@@ -12,7 +16,6 @@ import { Title } from '@angular/platform-browser';
 })
 export class BuildDetailsComponent implements OnInit, OnDestroy, AfterViewChecked {
   buildId: number;
-  project: WharfProject;
   buildStatus?: BuildStatus;
   myData: any;
   source: EventSource;
@@ -23,7 +26,6 @@ export class BuildDetailsComponent implements OnInit, OnDestroy, AfterViewChecke
 
   constructor(
     private route: ActivatedRoute,
-    private projectService: ProjectService,
     private buildService: BuildService,
     private configService: ConfigService,
     private titleService: Title) { }
@@ -33,11 +35,6 @@ export class BuildDetailsComponent implements OnInit, OnDestroy, AfterViewChecke
     this.buildService.buildBuildidGet(this.buildId).subscribe(build => {
       this.buildStatus = build.statusId;
       this.connect();
-    });
-    const projectId = Number(this.route.snapshot.paramMap.get('projectId'));
-    this.projectService.projectProjectidGet(projectId).subscribe(project => {
-      this.project = project;
-      this.updateTitle();
     });
   }
 
@@ -97,24 +94,10 @@ export class BuildDetailsComponent implements OnInit, OnDestroy, AfterViewChecke
   }
 
   private updateTitle() {
-    if (!this.project?.name) {
-      switch (this.activeTabIndex) {
-        case 0:
-          return this.titleService.setTitle(`Logs - Wharf`);
-        case 1:
-          return this.titleService.setTitle(`Artifacts - Wharf`);
-        default:
-          return this.titleService.setTitle(`Build - Wharf`);
-      }
-    }
-
-    switch (this.activeTabIndex) {
-      case 0:
-        return this.titleService.setTitle(`Logs - ${this.project.name} - Wharf`);
-      case 1:
-        return this.titleService.setTitle(`Artifacts - ${this.project.name} - Wharf`);
-      default:
-        return this.titleService.setTitle(`Build - ${this.project.name} - Wharf`);
+    if (this.activeTabIndex === Tabs.LOGS) {
+      this.titleService.setTitle(`Build ${this.buildId} - Wharf`);
+    } else if (this.activeTabIndex === Tabs.ARTIFACTS) {
+      this.titleService.setTitle(`Artifacts - Build ${this.buildId} - Wharf`);
     }
   }
 }

--- a/src/app/builds/build-details/build-details.component.ts
+++ b/src/app/builds/build-details/build-details.component.ts
@@ -6,8 +6,8 @@ import { BuildStatus } from '../../models/build-status';
 import { Title } from '@angular/platform-browser';
 
 const enum Tabs {
-  LOGS = 0,
-  ARTIFACTS,
+  Logs = 0,
+  Artifacts,
 }
 
 @Component({
@@ -96,9 +96,9 @@ export class BuildDetailsComponent implements OnInit, OnDestroy, AfterViewChecke
   }
 
   private updateTitle() {
-    if (this.activeTabIndex === Tabs.LOGS) {
+    if (this.activeTabIndex === Tabs.Logs) {
       this.titleService.setTitle(`Build ${this.buildId} - Wharf`);
-    } else if (this.activeTabIndex === Tabs.ARTIFACTS) {
+    } else if (this.activeTabIndex === Tabs.Artifacts) {
       this.titleService.setTitle(`Artifacts - Build ${this.buildId} - Wharf`);
     }
   }

--- a/src/app/projects/project-details/project-details.component.html
+++ b/src/app/projects/project-details/project-details.component.html
@@ -29,11 +29,10 @@
       </div>
     </div>
     <div class="project-page-body">
-      <wh-tabview-x *ngIf="project.buildHistory">
+      <wh-tabview-x [(activeIndex)]="activeTabIndex" (onChange)="onTabChanged()" *ngIf="project.buildHistory">
         <wh-tabpanel-x header="Builds">
           <ng-template pTemplate="side-header-override">
-            <p-splitButton *ngIf="project.actions"
-              class="button-container"
+            <p-splitButton *ngIf="project.actions" class="button-container"
               label="{{projectUtilsService.runAllActionName}}"
               [model]="projectUtilsService.getActionsMenuItems(project)"
               (onClick)="projectUtilsService.openActions(projectUtilsService.runAllActionName,project)">
@@ -43,15 +42,13 @@
         </wh-tabpanel-x>
         <wh-tabpanel-x>
           <ng-template pTemplate="header">
-            <span class="p-tabview-title">Configuration <i class="pi pi-exclamation-circle" *ngIf="!project.buildDefinition"></i></span>
+            <span class="p-tabview-title">Configuration <i class="pi pi-exclamation-circle"
+                *ngIf="!project.buildDefinition"></i></span>
           </ng-template>
           <ng-container *ngTemplateOutlet="configuration"></ng-container>
           <ng-template pTemplate="side-header-override">
-            <wh-project-refresh-button
-              #refreshButton
-              (refreshed)="reloadProject()"
-              [project]="project"
-              ></wh-project-refresh-button>
+            <wh-project-refresh-button #refreshButton (refreshed)="reloadProject()" [project]="project">
+            </wh-project-refresh-button>
           </ng-template>
         </wh-tabpanel-x>
         <wh-tabpanel-x header="Schedule" disabled="true" tooltip='This feature has not yet been implemented.
@@ -67,7 +64,8 @@
   </ng-template>
 
   <ng-template #configuration>
-    <wh-project-details-configuration [project]="project" (wantToRefresh)="refreshProject()"></wh-project-details-configuration>
+    <wh-project-details-configuration [project]="project" (wantToRefresh)="refreshProject()">
+    </wh-project-details-configuration>
   </ng-template>
 
   <ng-template #schedule>

--- a/src/app/projects/project-details/project-details.component.html
+++ b/src/app/projects/project-details/project-details.component.html
@@ -42,13 +42,16 @@
         </wh-tabpanel-x>
         <wh-tabpanel-x>
           <ng-template pTemplate="header">
-            <span class="p-tabview-title">Configuration <i class="pi pi-exclamation-circle"
-                *ngIf="!project.buildDefinition"></i></span>
+            <span class="p-tabview-title">
+              Configuration <i class="pi pi-exclamation-circle" *ngIf="!project.buildDefinition"></i>
+            </span>
           </ng-template>
           <ng-container *ngTemplateOutlet="configuration"></ng-container>
           <ng-template pTemplate="side-header-override">
-            <wh-project-refresh-button #refreshButton (refreshed)="reloadProject()" [project]="project">
-            </wh-project-refresh-button>
+            <wh-project-refresh-button
+              #refreshButton
+              (refreshed)="reloadProject()"
+              [project]="project"></wh-project-refresh-button>
           </ng-template>
         </wh-tabpanel-x>
         <wh-tabpanel-x header="Schedule" disabled="true" tooltip='This feature has not yet been implemented.
@@ -64,8 +67,9 @@
   </ng-template>
 
   <ng-template #configuration>
-    <wh-project-details-configuration [project]="project" (wantToRefresh)="refreshProject()">
-    </wh-project-details-configuration>
+    <wh-project-details-configuration
+      [project]="project"
+      (wantToRefresh)="refreshProject()"></wh-project-details-configuration>
   </ng-template>
 
   <ng-template #schedule>

--- a/src/app/projects/project-details/project-details.component.ts
+++ b/src/app/projects/project-details/project-details.component.ts
@@ -87,14 +87,12 @@ export class ProjectDetailsComponent implements OnInit {
   private updateTitle() {
     if (!this.project) {
       this.titleService.setTitle(`Loading... - Wharf`);
-    } else {
-      if (this.activeTabIndex === Tabs.BUILDS) {
-        this.titleService.setTitle(`${this.project.name} - Wharf`);
-      } else if (this.activeTabIndex === Tabs.CONFIGURATION) {
-        this.titleService.setTitle(`Configuration - ${this.project.name} - Wharf`);
-      } else if (this.activeTabIndex === Tabs.SCHEDULE) {
-        this.titleService.setTitle(`Schedule - ${this.project.name} - Wharf`);
-      }
+    } else if (this.activeTabIndex === Tabs.BUILDS) {
+      this.titleService.setTitle(`${this.project.name} - Wharf`);
+    } else if (this.activeTabIndex === Tabs.CONFIGURATION) {
+      this.titleService.setTitle(`Configuration - ${this.project.name} - Wharf`);
+    } else if (this.activeTabIndex === Tabs.SCHEDULE) {
+      this.titleService.setTitle(`Schedule - ${this.project.name} - Wharf`);
     }
   }
 }

--- a/src/app/projects/project-details/project-details.component.ts
+++ b/src/app/projects/project-details/project-details.component.ts
@@ -10,6 +10,12 @@ import { ProjectService } from 'api-client';
 import { ActivatedRoute } from '@angular/router';
 import { Title } from '@angular/platform-browser';
 
+const enum Tabs {
+  BUILDS = 0,
+  CONFIGURATION,
+  SCHEDULE,
+}
+
 @Component({
   selector: 'wh-project-details',
   templateUrl: './project-details.component.html',
@@ -80,27 +86,15 @@ export class ProjectDetailsComponent implements OnInit {
 
   private updateTitle() {
     if (!this.project) {
-      switch (this.activeTabIndex) {
-        case 0:
-          return this.titleService.setTitle(`Builds - Wharf`);
-        case 1:
-          return this.titleService.setTitle(`Configuration - Wharf`);
-        case 2:
-          return this.titleService.setTitle(`Schedule - Wharf`);
-        default:
-          return this.titleService.setTitle(`Project - Wharf`);
+      this.titleService.setTitle(`Loading... - Wharf`);
+    } else {
+      if (this.activeTabIndex === Tabs.BUILDS) {
+        this.titleService.setTitle(`${this.project.name} - Wharf`);
+      } else if (this.activeTabIndex === Tabs.CONFIGURATION) {
+        this.titleService.setTitle(`Configuration - ${this.project.name} - Wharf`);
+      } else if (this.activeTabIndex === Tabs.SCHEDULE) {
+        this.titleService.setTitle(`Schedule - ${this.project.name} - Wharf`);
       }
-    }
-
-    switch (this.activeTabIndex) {
-      case 0:
-        return this.titleService.setTitle(`Builds - ${this.project.name} - Wharf`);
-      case 1:
-        return this.titleService.setTitle(`Configuration - ${this.project.name} - Wharf`);
-      case 2:
-        return this.titleService.setTitle(`Schedule - ${this.project.name} - Wharf`);
-      default:
-        return this.titleService.setTitle(`${this.project.name} - Wharf`);
     }
   }
 }

--- a/src/app/projects/project-details/project-details.component.ts
+++ b/src/app/projects/project-details/project-details.component.ts
@@ -8,6 +8,7 @@ import { NotificationService } from 'src/app/shared/notification/notification.se
 import { ActionsModalStore } from '../actions-modal/actions-modal.service';
 import { ProjectService } from 'api-client';
 import { ActivatedRoute } from '@angular/router';
+import { Title } from '@angular/platform-browser';
 
 @Component({
   selector: 'wh-project-details',
@@ -22,6 +23,7 @@ export class ProjectDetailsComponent implements OnInit {
   buildsTotalCount = 0;
   rowsCount = 10;
   destroyed$ = new Subject<void>();
+  activeTabIndex = 0;
 
   constructor(
     public projectUtilsService: ProjectUtilsService,
@@ -30,10 +32,16 @@ export class ProjectDetailsComponent implements OnInit {
     private actionsModalStore: ActionsModalStore,
     private projectService: ProjectService,
     private route: ActivatedRoute,
+    private titleService: Title,
   ) { }
 
   ngOnInit(): void {
     this.reloadProject();
+    this.updateTitle();
+  }
+
+  onTabChanged() {
+    this.updateTitle();
   }
 
   reloadProject() {
@@ -42,6 +50,7 @@ export class ProjectDetailsComponent implements OnInit {
       this.project = project;
       // Temporary initialization to render table, after that loadBuildsLazy handles builds fetching
       this.project.buildHistory = [];
+      this.updateTitle();
     });
 
     this.actionsModalStore.isVisible$.pipe(takeUntil(this.destroyed$)).subscribe(x => this.isActionsFormVisible = x);
@@ -67,5 +76,18 @@ export class ProjectDetailsComponent implements OnInit {
       this.notificationService.showWarning('Failed to copy to clipboard');
     }
     selection.removeAllRanges();
+  }
+
+  private updateTitle() {
+    switch (this.activeTabIndex) {
+      case 0:
+        return this.titleService.setTitle(`Builds - ${this.project.name} - Wharf`);
+      case 1:
+        return this.titleService.setTitle(`Configuration - ${this.project.name} - Wharf`);
+      case 2:
+        return this.titleService.setTitle(`Schedule - ${this.project.name} - Wharf`);
+      default:
+        return this.titleService.setTitle(`${this.project.name} - Wharf`);
+    }
   }
 }

--- a/src/app/projects/project-details/project-details.component.ts
+++ b/src/app/projects/project-details/project-details.component.ts
@@ -79,6 +79,19 @@ export class ProjectDetailsComponent implements OnInit {
   }
 
   private updateTitle() {
+    if (!this.project) {
+      switch (this.activeTabIndex) {
+        case 0:
+          return this.titleService.setTitle(`Builds - Wharf`);
+        case 1:
+          return this.titleService.setTitle(`Configuration - Wharf`);
+        case 2:
+          return this.titleService.setTitle(`Schedule - Wharf`);
+        default:
+          return this.titleService.setTitle(`Project - Wharf`);
+      }
+    }
+
     switch (this.activeTabIndex) {
       case 0:
         return this.titleService.setTitle(`Builds - ${this.project.name} - Wharf`);

--- a/src/app/projects/project-details/project-details.component.ts
+++ b/src/app/projects/project-details/project-details.component.ts
@@ -11,9 +11,9 @@ import { ActivatedRoute } from '@angular/router';
 import { Title } from '@angular/platform-browser';
 
 const enum Tabs {
-  BUILDS = 0,
-  CONFIGURATION,
-  SCHEDULE,
+  Builds = 0,
+  Configuration,
+  Schedule,
 }
 
 @Component({
@@ -87,11 +87,11 @@ export class ProjectDetailsComponent implements OnInit {
   private updateTitle() {
     if (!this.project) {
       this.titleService.setTitle(`Loading... - Wharf`);
-    } else if (this.activeTabIndex === Tabs.BUILDS) {
+    } else if (this.activeTabIndex === Tabs.Builds) {
       this.titleService.setTitle(`${this.project.name} - Wharf`);
-    } else if (this.activeTabIndex === Tabs.CONFIGURATION) {
+    } else if (this.activeTabIndex === Tabs.Configuration) {
       this.titleService.setTitle(`Configuration - ${this.project.name} - Wharf`);
-    } else if (this.activeTabIndex === Tabs.SCHEDULE) {
+    } else if (this.activeTabIndex === Tabs.Schedule) {
       this.titleService.setTitle(`Schedule - ${this.project.name} - Wharf`);
     }
   }

--- a/src/app/projects/project-list/project-list.component.html
+++ b/src/app/projects/project-list/project-list.component.html
@@ -20,7 +20,12 @@
   </wh-tabview-x>
 
   <ng-template #template let-projects="projects">
-    <p-table #dt class="project-list" [value]="projects" [paginator]="true" [rows]="14"
+    <p-table
+      #dt
+      class="project-list"
+      [value]="projects"
+      [paginator]="true"
+      [rows]="14"
       [globalFilterFields]="['name', 'groupName', 'gitUrl']">
       <ng-template pTemplate="header">
         <tr>
@@ -33,9 +38,12 @@
         </tr>
       </ng-template>
       <ng-template pTemplate="body" let-project>
-        <wh-project-list-item [project]="project" (refreshed)="onProjectRefreshed($event)"
-          (favoriteClick)="initFavoriteProjects()" role="button" (click)="onProjectRowClicked($event, project)">
-        </wh-project-list-item>
+        <wh-project-list-item
+          [project]="project"
+          (refreshed)="onProjectRefreshed($event)"
+          (favoriteClick)="initFavoriteProjects()"
+          role="button"
+          (click)="onProjectRowClicked($event, project)"></wh-project-list-item>
       </ng-template>
     </p-table>
   </ng-template>

--- a/src/app/projects/project-list/project-list.component.html
+++ b/src/app/projects/project-list/project-list.component.html
@@ -1,5 +1,5 @@
 <section>
-  <wh-tabview-x [(activeIndex)]="activeTabIndex">
+  <wh-tabview-x [(activeIndex)]="activeTabIndex" (onChange)="onTabChanged()">
     <wh-tabpanel-x header="All Projects">
       <ng-container *ngTemplateOutlet="template;context:{projects:
         this.projects}"></ng-container>
@@ -12,7 +12,7 @@
       <div class="project-search">
         <div class="p-inputgroup">
           <span class="p-inputgroup-addon"><i class="pi pi-search"></i></span>
-          <input type="text" pInputText placeholder="Search" (keyup)="onSearchKeyUp($event)"/>
+          <input type="text" pInputText placeholder="Search" (keyup)="onSearchKeyUp($event)" />
         </div>
       </div>
       <wh-provider></wh-provider>
@@ -20,12 +20,7 @@
   </wh-tabview-x>
 
   <ng-template #template let-projects="projects">
-    <p-table
-      #dt
-      class="project-list"
-      [value]="projects"
-      [paginator]="true"
-      [rows]="14"
+    <p-table #dt class="project-list" [value]="projects" [paginator]="true" [rows]="14"
       [globalFilterFields]="['name', 'groupName', 'gitUrl']">
       <ng-template pTemplate="header">
         <tr>
@@ -38,12 +33,9 @@
         </tr>
       </ng-template>
       <ng-template pTemplate="body" let-project>
-        <wh-project-list-item
-          [project]="project"
-          (refreshed)="onProjectRefreshed($event)"
-          (favoriteClick)="initFavoriteProjects()"
-          role="button"
-          (click)="onProjectRowClicked($event, project)"></wh-project-list-item>
+        <wh-project-list-item [project]="project" (refreshed)="onProjectRefreshed($event)"
+          (favoriteClick)="initFavoriteProjects()" role="button" (click)="onProjectRowClicked($event, project)">
+        </wh-project-list-item>
       </ng-template>
     </p-table>
   </ng-template>

--- a/src/app/projects/project-list/project-list.component.ts
+++ b/src/app/projects/project-list/project-list.component.ts
@@ -12,6 +12,11 @@ import { ProjectRefreshedEvent } from '../project-refresh';
 import { LocalStorageProjectsService } from './../local-storage-projects.service';
 import { Title } from '@angular/platform-browser';
 
+const enum Tabs {
+  ALL = 0,
+  FAVORITES,
+}
+
 @Component({
   selector: 'wh-project-list',
   templateUrl: './project-list.component.html',
@@ -106,10 +111,10 @@ export class ProjectListComponent implements OnInit {
   }
 
   private updateTitle() {
-    if (this.activeTabIndex === 1) {
-      this.titleService.setTitle('Favorite projects - Wharf');
-    } else {
+    if (this.activeTabIndex === Tabs.ALL) {
       this.titleService.setTitle('All projects - Wharf');
+    } else if (this.activeTabIndex === Tabs.FAVORITES) {
+      this.titleService.setTitle('Favorite projects - Wharf');
     }
   }
 }

--- a/src/app/projects/project-list/project-list.component.ts
+++ b/src/app/projects/project-list/project-list.component.ts
@@ -10,6 +10,7 @@ import { ProvidersService } from 'src/app/providers/providers.service';
 import { ActionsModalStore } from '../actions-modal/actions-modal.service';
 import { ProjectRefreshedEvent } from '../project-refresh';
 import { LocalStorageProjectsService } from './../local-storage-projects.service';
+import { Title } from '@angular/platform-browser';
 
 @Component({
   selector: 'wh-project-list',
@@ -36,6 +37,7 @@ export class ProjectListComponent implements OnInit {
     private providersService: ProvidersService,
     private actionsModalStore: ActionsModalStore,
     private router: Router,
+    private titleService: Title,
   ) { }
 
   ngOnInit(): void {
@@ -44,6 +46,7 @@ export class ProjectListComponent implements OnInit {
     this.providersService.formClosed$.pipe(takeUntil(this.destroyed$)).subscribe(() => this.loadProjects());
     this.actionsModalStore.isVisible$.pipe(takeUntil(this.destroyed$)).subscribe(x => this.isActionsFormVisible = x);
     this.viewFavoritesTabIfAny();
+    this.updateTitle();
   }
 
   onSearchKeyUp(event: KeyboardEvent) {
@@ -59,6 +62,10 @@ export class ProjectListComponent implements OnInit {
 
   onProjectRefreshed(event: ProjectRefreshedEvent) {
     this.replaceProject(event.projectId);
+  }
+
+  onTabChanged() {
+    this.updateTitle();
   }
 
   viewFavoritesTabIfAny() {
@@ -96,5 +103,13 @@ export class ProjectListComponent implements OnInit {
       this.projects = val;
       this.initFavoriteProjects();
     });
+  }
+
+  private updateTitle() {
+    if (this.activeTabIndex === 1) {
+      this.titleService.setTitle('Favorite projects - Wharf');
+    } else {
+      this.titleService.setTitle('All projects - Wharf');
+    }
   }
 }

--- a/src/app/projects/project-list/project-list.component.ts
+++ b/src/app/projects/project-list/project-list.component.ts
@@ -106,13 +106,10 @@ export class ProjectListComponent implements OnInit {
   }
 
   private updateTitle() {
-    switch (this.activeTabIndex) {
-      case 0:
-        return this.titleService.setTitle('All projects - Wharf');
-      case 1:
-        return this.titleService.setTitle('Favorite projects - Wharf');
-      default:
-        return this.titleService.setTitle('Wharf');
+    if (this.activeTabIndex === 1) {
+      this.titleService.setTitle('Favorite projects - Wharf');
+    } else {
+      this.titleService.setTitle('All projects - Wharf');
     }
   }
 }

--- a/src/app/projects/project-list/project-list.component.ts
+++ b/src/app/projects/project-list/project-list.component.ts
@@ -106,10 +106,13 @@ export class ProjectListComponent implements OnInit {
   }
 
   private updateTitle() {
-    if (this.activeTabIndex === 1) {
-      this.titleService.setTitle('Favorite projects - Wharf');
-    } else {
-      this.titleService.setTitle('All projects - Wharf');
+    switch (this.activeTabIndex) {
+      case 0:
+        return this.titleService.setTitle('All projects - Wharf');
+      case 1:
+        return this.titleService.setTitle('Favorite projects - Wharf');
+      default:
+        return this.titleService.setTitle('Wharf');
     }
   }
 }

--- a/src/app/projects/project-list/project-list.component.ts
+++ b/src/app/projects/project-list/project-list.component.ts
@@ -13,8 +13,8 @@ import { LocalStorageProjectsService } from './../local-storage-projects.service
 import { Title } from '@angular/platform-browser';
 
 const enum Tabs {
-  ALL = 0,
-  FAVORITES,
+  All = 0,
+  Favorites,
 }
 
 @Component({
@@ -111,9 +111,9 @@ export class ProjectListComponent implements OnInit {
   }
 
   private updateTitle() {
-    if (this.activeTabIndex === Tabs.ALL) {
+    if (this.activeTabIndex === Tabs.All) {
       this.titleService.setTitle('All projects - Wharf');
-    } else if (this.activeTabIndex === Tabs.FAVORITES) {
+    } else if (this.activeTabIndex === Tabs.Favorites) {
       this.titleService.setTitle('Favorite projects - Wharf');
     }
   }

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8">
-  <title>wharf</title>
+  <title>Wharf</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">

--- a/src/index.html
+++ b/src/index.html
@@ -1,13 +1,16 @@
 <!doctype html>
 <html lang="en">
+
 <head>
-<meta charset="utf-8">
+  <meta charset="utf-8">
   <title>wharf</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>
+
 <body>
   <wh-app-root></wh-app-root>
 </body>
+
 </html>


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

Added descriptive titles to the different views.

If you're looking at all projects, the tab's title will now be `All projects - Wharf`.
For favorite projects: `Favorite projects - Wharf`.

For project details
- `Builds - project_name - Wharf`
- `Configurations - project_name - Wharf`
- `Schedule - project_name - Wharf`

For build details
- `Logs - project_name - Wharf`
- `Artifacts - project_name - Wharf`

Closes #21

## Motivation

What bug or problem does this solve?

It makes it easier to know which tab is what for the user if they have multiple tabs open.