### PR TITLE
Fixed build logs page scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v1.3.4 (WIP)
+
+- Fixed page not scrolling down when new build logs arrive in bulk and the page
+  is scrolled to the bottom. (#60)
+
 ## v1.3.3 (2021-07-13)
 
 - Security fix by changing version of nginx base image in Dockerfile from

--- a/src/app/builds/build-details/build-details.component.ts
+++ b/src/app/builds/build-details/build-details.component.ts
@@ -18,6 +18,7 @@ export class BuildDetailsComponent implements OnInit, OnDestroy, AfterViewChecke
   listener: any = null;
   logEvents: MainLog[] = [];
   container: HTMLElement;
+  wasScrolledToBottom: boolean;
 
   constructor(
     private route: ActivatedRoute,
@@ -44,6 +45,7 @@ export class BuildDetailsComponent implements OnInit, OnDestroy, AfterViewChecke
       }
       if (!!window.EventSource && !this.listener) {
         this.source.addEventListener('message', (message: MessageEvent) => {
+          this.wasScrolledToBottom = this.isScrolledToBottom();
           // When it comes to SSE, the MessageEvent.data is always a string
           const data = JSON.parse(message.data);
           this.logEvents.push(data);
@@ -69,7 +71,7 @@ export class BuildDetailsComponent implements OnInit, OnDestroy, AfterViewChecke
   }
 
   private stayScrolledToBottom(): void {
-    if (this.isScrolledToBottom()) {
+    if (this.wasScrolledToBottom) {
       this.scrollToBottom();
     }
   }


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

Fixed the build logs page not scrolling down when already scrolled down and new logs arrive in bulk.

Closes #57

## Motivation

Having to continuously scroll to keep up with the logs isn't something anybody wants to do. Now nobody has to.