### PR TITLE
Release v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v1.4.0 (2021-09-09)
+## v1.4.0 (2021-09-10)
 
 - Added toast message support for IETF RFC-7807 formatted error responses.
   These toasts provide better help for resolving issues, and include a link to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,12 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v1.4.0 (WIP)
+## v1.4.0 (2021-09-09)
 
 - Added toast message support for IETF RFC-7807 formatted error responses.
   These toasts provide better help for resolving issues, and include a link to
   the error in question's documentation page. (#54)
-  
+
 - Added functionality for favoriting/unfavoriting a project in the project
   details view. (#58)
 


### PR DESCRIPTION
- \[x] I've updated the `(WIP)` tag to today's date in `CHANGELOG.md`
- \[x] I've added the `release` label to this PR
- \[x] Waiting for #66 to be merged first

## Changes

- Added toast message support for IETF RFC-7807 formatted error responses. These toasts provide better help for resolving issues, and include a link to the error in question's documentation page. (#54)

- Added functionality for favoriting/unfavoriting a project in the project details view. (#58)

- Fixed page not scrolling down when new build logs arrive in bulk and the page is scrolled to the bottom. (#60)

- Changed tab title to be descriptive, changing based on what view you're in. Previously it was just `wharf` no matter the view. (#59)

- Changed version of Docker base images, relying on "latest" patch version:

  - `nginx` from 1.21.0 to 1.21. (#66)
  - `node` from 14.17.1 to 14.17. (#66)

- Removed build dependencies `python` and `make` inside Dockerfile as they do not seem relevant any more. (#66)

- Security fix by changing version of `libgcrypt` from v1.9.3 to v1.9.4 in `nginx` Docker base image to resolve [CVE-2021-33560](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-33560), as that package has not yet been updated in the remote `nginx` Docker image. (#66)

## Actions after merge

Follow the step-by-step guide found here:
<https://iver-wharf.github.io/#/development/releasing-a-new-version?id=merging-a-release-pr>
