### PR TITLE
Use ng build -c production instead of --prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
-    "build-prod": "ng build --prod",
+    "build-prod": "ng build -c production",
     "build-clients": "ng build api-client && ng build import-gitlab-client && ng build import-github-client && ng build import-azuredevops-client",
     "test": "ng test",
     "lint": "ng lint && remark . && stylelint 'src/**/*.scss'",


### PR DESCRIPTION
- \[ ] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Changed from `ng build --prod` to `ng build -c production` in the `build-prod` script inside `package.json`

## Motivation

When building we get this warning:

```console
$ ng build-prod
> wharf@0.0.0 build-prod
> ng build --prod

...
Option "--prod" is deprecated: Use "--configuration production" instead.
...
```
