### PR TITLE
Fixed various docker vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,19 +29,16 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Changed version of Docker base images, relying on "latest" patch version:
 
-  - `nginx` from 1.21.0 to 1.21. (#?)
-  - `node` from 14.17.1 to 14.17. (#?)
+  - `nginx` from 1.21.0 to 1.21. (#66)
+  - `node` from 14.17.1 to 14.17. (#66)
 
-- Changed version of build dependencies inside Dockerfile, relying on "latest"
-  patch version:
-
-  - `python` from 2.7.18 to 2.7. (#?)
-  - `make` from 4.2.1 to 4.3. (#?)
+- Removed build dependencies `python` and `make` inside Dockerfile as they do
+  not seem relevant any more. (#66)
 
 - Security fix by changing version of `libgcrypt` from v1.9.3 to v1.9.4 in
   `nginx` Docker base image to resolve [CVE-2021-33560](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-33560),
   as that package has not yet been updated in the remote `nginx` Docker image.
-  (#?)
+  (#66)
 
 ## v1.3.3 (2021-07-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Added toast message support for IETF RFC-7807 formatted error responses.
   These toasts provide better help for resolving issues, and include a link to
   the error in question's documentation page. (#54)
-  
+
 - Added functionality for favoriting/unfavoriting a project in the project
   details view. (#58)
 
@@ -26,6 +26,22 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Changed tab title to be descriptive, changing based on what view you're in.
   Previously it was just `wharf` no matter the view. (#59)
+
+- Changed version of Docker base images, relying on "latest" patch version:
+
+  - `nginx` from 1.21.0 to 1.21. (#?)
+  - `node` from 14.17.1 to 14.17. (#?)
+
+- Changed version of build dependencies inside Dockerfile, relying on "latest"
+  patch version:
+
+  - `python` from 2.7.18 to 2.7. (#?)
+  - `make` from 4.2.1 to 4.3. (#?)
+
+- Security fix by changing version of `libgcrypt` from v1.9.3 to v1.9.4 in
+  `nginx` Docker base image to resolve [CVE-2021-33560](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-33560),
+  as that package has not yet been updated in the remote `nginx` Docker image.
+  (#?)
 
 ## v1.3.3 (2021-07-13)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM node:14.17.1-alpine3.11 AS build
+FROM node:14.17-alpine3.14 AS build
 
 # Set working directory
 WORKDIR /usr/src/app
 
 # Install dependencies
 RUN apk add --no-cache \
-    python=~2.7.18 \
-    make=~4.2.1
+    python2=~2.7 \
+    make=~4.3
 
 # node_modules to path
 ENV PATH /usr/src/app/node_modules/.bin:$PATH
@@ -27,7 +27,11 @@ RUN deploy/update-typescript-environments.sh src/environments/environment.prod.t
     && npm run build-clients \
     && npm run build-prod
 
-FROM nginx:1.21.1-alpine
+FROM nginx:1.21-alpine
+
+RUN apk add --upgrade --no-cache \
+    libgcrypt>=1.9.4 # Resolves CVE-2021-33560, as it's not yet upgraded in upstream image
+
 COPY --from=build /usr/src/app/dist/wharf /usr/share/nginx/html
 COPY ./deploy/nginx.conf /etc/nginx/conf.d/default.conf
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.17-alpine3.14 AS build
+FROM node:14-alpine AS build
 
 # Set working directory
 WORKDIR /usr/src/app
@@ -22,7 +22,7 @@ RUN deploy/update-typescript-environments.sh src/environments/environment.prod.t
     && npm run build-clients \
     && npm run build-prod
 
-FROM nginx:1.21-alpine
+FROM nginx:1-alpine
 
 RUN apk add --upgrade --no-cache \
     libgcrypt>=1.9.4 # Resolves CVE-2021-33560, as it's not yet upgraded in upstream image

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,6 @@ FROM node:14.17-alpine3.14 AS build
 # Set working directory
 WORKDIR /usr/src/app
 
-# Install dependencies
-RUN apk add --no-cache \
-    python2=~2.7 \
-    make=~4.3
-
 # node_modules to path
 ENV PATH /usr/src/app/node_modules/.bin:$PATH
 ENV HOME /tmp


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Strip away patch version from docker base images.
- Removed building dependencies `make` and `python`. They were introduced pre-GitHub with no comment on why they were needed. The docker build succeeds without them, so gone they go.
- Force update `libgcrypt` from `nginx` Docker base image.

## Motivation

Resolve vulnerability issues reported by `trivy`, which is used to scan in both quay.io and harbor.
