### PR TITLE
Removed per-tab title for build & project details pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v1.4.1 (WIP)
+
+- Removed per-tab titles on project details page. Title is now either
+  `Loading... - Wharf` or `{project name} - Wharf`, no matter which tab
+  you're on. (#69)
+
+- Removed per-tab titles on build details page. Title is now
+  `Build {build ID} - Wharf`, no matter which tab you're on. (#69)
+
 ## v1.4.0 (2021-09-10)
 
 - Added toast message support for IETF RFC-7807 formatted error responses.

--- a/src/app/builds/build-details/build-details.component.html
+++ b/src/app/builds/build-details/build-details.component.html
@@ -1,5 +1,5 @@
 <section class="projects-container">
-  <wh-tabview-x [(activeIndex)]="activeTabIndex" (onChange)="onTabChanged()">
+  <wh-tabview-x (onChange)="onTabChanged()">
     <wh-tabpanel-x id="build-logs" header="Logs">
       <ng-container *ngTemplateOutlet="buildDataView"></ng-container>
     </wh-tabpanel-x>

--- a/src/app/builds/build-details/build-details.component.ts
+++ b/src/app/builds/build-details/build-details.component.ts
@@ -5,11 +5,6 @@ import { BuildService, MainLog } from 'api-client';
 import { BuildStatus } from '../../models/build-status';
 import { Title } from '@angular/platform-browser';
 
-const enum Tabs {
-  Logs = 0,
-  Artifacts,
-}
-
 @Component({
   selector: 'wh-build-details',
   templateUrl: './build-details.component.html',
@@ -22,7 +17,6 @@ export class BuildDetailsComponent implements OnInit, OnDestroy, AfterViewChecke
   listener: any = null;
   logEvents: MainLog[] = [];
   container: HTMLElement;
-  activeTabIndex = 0;
   wasScrolledToBottom: boolean;
 
   constructor(
@@ -96,10 +90,6 @@ export class BuildDetailsComponent implements OnInit, OnDestroy, AfterViewChecke
   }
 
   private updateTitle() {
-    if (this.activeTabIndex === Tabs.Logs) {
-      this.titleService.setTitle(`Build ${this.buildId} - Wharf`);
-    } else if (this.activeTabIndex === Tabs.Artifacts) {
-      this.titleService.setTitle(`Artifacts - Build ${this.buildId} - Wharf`);
-    }
+    this.titleService.setTitle(`Build ${this.buildId} - Wharf`);
   }
 }

--- a/src/app/projects/project-details/project-details.component.html
+++ b/src/app/projects/project-details/project-details.component.html
@@ -27,7 +27,7 @@
       </div>
     </div>
     <div class="project-page-body">
-      <wh-tabview-x [(activeIndex)]="activeTabIndex" (onChange)="onTabChanged()" *ngIf="project.buildHistory">
+      <wh-tabview-x (onChange)="onTabChanged()" *ngIf="project.buildHistory">
         <wh-tabpanel-x header="Builds">
           <ng-template pTemplate="side-header-override">
             <p-splitButton *ngIf="project.actions" class="button-container"

--- a/src/app/projects/project-details/project-details.component.ts
+++ b/src/app/projects/project-details/project-details.component.ts
@@ -10,12 +10,6 @@ import { ProjectService } from 'api-client';
 import { ActivatedRoute } from '@angular/router';
 import { Title } from '@angular/platform-browser';
 
-const enum Tabs {
-  Builds = 0,
-  Configuration,
-  Schedule,
-}
-
 @Component({
   selector: 'wh-project-details',
   templateUrl: './project-details.component.html',
@@ -29,7 +23,6 @@ export class ProjectDetailsComponent implements OnInit {
   buildsTotalCount = 0;
   rowsCount = 10;
   destroyed$ = new Subject<void>();
-  activeTabIndex = 0;
 
   constructor(
     public projectUtilsService: ProjectUtilsService,
@@ -87,12 +80,8 @@ export class ProjectDetailsComponent implements OnInit {
   private updateTitle() {
     if (!this.project) {
       this.titleService.setTitle(`Loading... - Wharf`);
-    } else if (this.activeTabIndex === Tabs.Builds) {
+    } else {
       this.titleService.setTitle(`${this.project.name} - Wharf`);
-    } else if (this.activeTabIndex === Tabs.Configuration) {
-      this.titleService.setTitle(`Configuration - ${this.project.name} - Wharf`);
-    } else if (this.activeTabIndex === Tabs.Schedule) {
-      this.titleService.setTitle(`Schedule - ${this.project.name} - Wharf`);
     }
   }
 }


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Removed per-tab titles on project details page. Title is now either `Loading... - Wharf` or `{project name} - Wharf`.
- Removed per-tab titles on build details page. Title is now `Build {build ID} - Wharf`

## Motivation

The titles got bloated real quick. There's not much place in the title, and IMO knowing if you're on the configuration or build list is just TMI.

This is personal opinion, so please reject this PR if you don't agree.

## Preview

This is how it is currently in v1.4.0:

Build details:
![Screenshot from 2021-09-10 16-23-20](https://user-images.githubusercontent.com/2477952/132869026-03db34f4-aa00-4167-95c1-9979d8d85640.png)
![Screenshot from 2021-09-10 16-23-28](https://user-images.githubusercontent.com/2477952/132869029-862fc568-ec62-43a7-9d9c-2ec09b216ba2.png)

Project details:
![Screenshot from 2021-09-10 16-23-50](https://user-images.githubusercontent.com/2477952/132869034-963176c8-b2e3-40fc-b997-d15ae19dd889.png)
![Screenshot from 2021-09-10 16-23-56](https://user-images.githubusercontent.com/2477952/132869035-a1d809f2-f1c2-4ce5-a117-c19039d3ea96.png)

This PR would change so only the former format for the above details pages are used.