### PR TITLE
Updated config to allow local dev

### DIFF
--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -12,9 +12,9 @@
         "silentRenewEndpoint": "/assets/silent-renew.html"
     },
     "backendUrls": {
-        "Api": "http://localhost:5000/api",
-        "GitlabImport": "http://localhost:5000/import",
-        "GithubImport": "http://localhost:5000/import",
-        "AzureDevopsImport": "http://localhost:5000/import"
+        "Api": "http://localhost:5001/api",
+        "GitlabImport": "http://localhost:5002/import",
+        "GithubImport": "http://localhost:5003/import",
+        "AzureDevopsImport": "http://localhost:5004/import"
     }
 }


### PR DESCRIPTION
- \[ ] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Updated ports in `src/assets/config.json` to reference each service's distinct port.

## Motivation

Similar to the one from iver-wharf/wharf-api#85

The docker-compose already publishes these ports. This change makes the wharf-web talk directly to the services instead of talking via the traefik.

Benefit of this is that you (dev) can host these services locally, without docker-compose, and the web can still access them.
