### PR TITLE
Makefile: added 'clients' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ docker-run:
 serve: clients
 	npm start
 
+clients-force:
+	npm run build-clients
+
 clients:
 ifeq ("$(wildcard dist/api-client)","")
 	npx ng build api-client

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,23 @@ endif
 docker-run:
 	docker run --rm -it quay.io/iver-wharf/wharf-web:$(version)
 
-serve: swag
+serve: clients
 	npm start
+
+clients:
+ifeq ("$(wildcard dist/api-client)","")
+	npx ng build api-client
+endif
+ifeq ("$(wildcard dist/import-gitlab-client)","")
+	npx ng build import-gitlab-client
+endif
+ifeq ("$(wildcard dist/import-github-client)","")
+	npx ng build import-github-client
+endif
+ifeq ("$(wildcard dist/import-azuredevops-client)","")
+	npx ng build import-azuredevops-client
+endif
+	@# This comment silences warning "make: Nothing to be done for 'clients'."
 
 deps:
 	npm install


### PR DESCRIPTION
- \[ ] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added `clients` target, that builds the clients that are missing in `dist/*-client`.
- Updated `serve` target to depend on `clients`, instead of the undefined `swag` target

## Motivation

This makes `make serve` useful. Doesn't rebuild stuff if it isn't needed.

Inspired by iver-wharf/wharf-api#84

