### PR TITLE
Changed nginx to use try_files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Changed RxJS `subscribe` calls to use new signature in preparation for
   RxJS v8. (#77)
 
+- Fixed issue where all non-root URL paths returned 404 from Nginx in
+  Dockerfile even through they were valid paths, such as `/projects/1`. (#80)
+
 ## v1.4.0 (2021-09-10)
 
 - Added toast message support for IETF RFC-7807 formatted error responses.

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -2,21 +2,11 @@ server {
     listen       8080;
     server_name  localhost;
     add_header X-Clacks-Overhead "GNU Terry Pratchett";
+    root   /usr/share/nginx/html;
+    index index.html;
 
     location / {
-        root   /usr/share/nginx/html;
-        index  index.html index.htm;
-    }
-
-    error_page 404 @rewrites;
-
-    error_page   500 502 503 504  /50x.html;
-    location = /50x.html {
-        root   /usr/share/nginx/html;
-    }
-
-    location @rewrites {
-        rewrite ^(.+)$ /index.html last;
+        try_files $uri$args $uri$args/ /index.html;
     }
 }
 


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Changed `location` statement in `deploy/nginx.conf` to use `try_files` instead
- Removed all 4xx and 5xx handling from Nginx, leaving that for the Angular site to deal with instead.

## Motivation

It previously returned status code 404 on any page except the root `/`. Now it correctly returns status code 200 instead, and the Angular code will have to deal with unknown pages instead.

Took inspiration from this guide: <https://betterprogramming.pub/how-to-properly-get-angular-and-nginx-working-together-for-development-3e5d158734bf>

Closes #44
