### PR TITLE
Fixed clone URL wrapping instead of ellipsis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Changed side nav to have `position: fixed`, meaning it will no longer scroll
   with the rest of the page. (#82)
 
+- Fixed invalid ellipsis overflow in Git SSH clone URL on project details page
+  caused by wrapping characters (e.g dash `-`). (#87)
+
 ## v1.4.0 (2021-09-10)
 
 - Added toast message support for IETF RFC-7807 formatted error responses.

--- a/src/scss/project-details.component.scss
+++ b/src/scss/project-details.component.scss
@@ -54,6 +54,7 @@
         height: 1.25rem;
         width: 10.5rem;
         font-size: 80%;
+        white-space: nowrap;
       }
     }
 


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added CSS `white-space: nowrap` to clone URL

## Motivation

For URLs that contains wrappable characters (e.g dash `-`) it wraps the URL. It's only 1 line, so the wrapped text is just missing instead. We do have `overflow: ellipsis`, so it should use that instead.

This PR fixes that

## Preview

Before

![Screenshot from 2021-11-09 09-05-06](https://user-images.githubusercontent.com/2477952/140889200-1b100b78-9cf1-4cce-b535-35de3484742c.png)

After

![Screenshot from 2021-11-09 09-05-58](https://user-images.githubusercontent.com/2477952/140889197-d99b7849-c28b-4cca-bebe-64c9c4c7e2d9.png)