### PR TITLE
Upgrade cURL to resolve CVE-2021-22945

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Fixed invalid ellipsis overflow in Git SSH clone URL on project details page
   caused by wrapping characters (e.g dash `-`). (#87)
 
+- Security fix by changing version of `curl` and `libcurl` from v7.78.0 to
+  v7.79.1 in `nginx` Docker base image to resolve [CVE-2021-22945](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22945),
+  as that package has not yet been updated in the upstream `nginx` Docker image.
+  (#88)
+
 ## v1.4.0 (2021-09-10)
 
 - Added toast message support for IETF RFC-7807 formatted error responses.

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,9 @@ RUN deploy/update-typescript-environments.sh src/environments/environment.prod.t
 FROM nginx:1-alpine
 
 RUN apk add --upgrade --no-cache \
-    libgcrypt>=1.9.4 # Resolves CVE-2021-33560, as it's not yet upgraded in upstream image
+    # Resolves CVE-2021-22945, as it's not yet upgraded in upstream image
+    curl>7.78.0 \
+    libcurl>7.78.0
 
 COPY --from=build /usr/src/app/dist/wharf /usr/share/nginx/html
 COPY ./deploy/nginx.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Upgrade cURL and libcurl to above 7.78.0 to dismiss CVE-2021-22945

## Motivation

Not yet fixed in upstream image: https://github.com/nginxinc/docker-nginx/issues/589
