### PR TITLE
Changed .wharf-ci.yml for canary builds

### DIFF
--- a/.wharf-ci.yml
+++ b/.wharf-ci.yml
@@ -1,9 +1,9 @@
 build:
-  web-ng:
+  wharf-web:
     docker:
       file: Dockerfile
-      tag: ${GIT_TAG},latest
+      tag: unstable
       args:
-        - WHARF_WEB_VERSION=${GIT_TAG}
-        - WHARF_WEB_CI_GIT_COMMIT=${GIT_COMMIT}
-        - WHARF_WEB_CI_BUILD_REF=${BUILD_REF}
+        - BUILD_VERSION=${GIT_BRANCH}
+        - BUILD_GIT_COMMIT=${GIT_COMMIT}
+        - BUILD_REF=${BUILD_REF}

--- a/.wharf-ci.yml
+++ b/.wharf-ci.yml
@@ -2,7 +2,7 @@ build:
   wharf-web:
     docker:
       file: Dockerfile
-      tag: unstable
+      tag: canary
       args:
         - BUILD_VERSION=${GIT_BRANCH}
         - BUILD_GIT_COMMIT=${GIT_COMMIT}

--- a/.wharf-ci.yml
+++ b/.wharf-ci.yml
@@ -4,6 +4,6 @@ build:
       file: Dockerfile
       tag: unstable
       args:
-        - BUILD_VERSION=${GIT_SAFEBRANCH}
+        - BUILD_VERSION=${GIT_BRANCH}
         - BUILD_GIT_COMMIT=${GIT_COMMIT}
         - BUILD_REF=${BUILD_REF}

--- a/.wharf-ci.yml
+++ b/.wharf-ci.yml
@@ -4,6 +4,6 @@ build:
       file: Dockerfile
       tag: unstable
       args:
-        - BUILD_VERSION=${GIT_BRANCH}
+        - BUILD_VERSION=${GIT_SAFEBRANCH}
         - BUILD_GIT_COMMIT=${GIT_COMMIT}
         - BUILD_REF=${BUILD_REF}

--- a/.wharf-ci.yml
+++ b/.wharf-ci.yml
@@ -7,3 +7,4 @@ build:
         - BUILD_VERSION=${GIT_BRANCH}
         - BUILD_GIT_COMMIT=${GIT_COMMIT}
         - BUILD_REF=${BUILD_REF}
+        - REG=${REG_URL}/hub

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:14-alpine AS build
+ARG REG=docker.io
+FROM ${REG}/library/node:14-alpine AS build
 
 # Set working directory
 WORKDIR /usr/src/app
@@ -24,7 +25,8 @@ RUN deploy/update-typescript-environments.sh src/environments/environment.prod.t
     && npm run collect-licenses \
     && npm run build-prod
 
-FROM nginx:1-alpine
+ARG REG=docker.io
+FROM ${REG}/library/nginx:1-alpine
 
 RUN apk add --upgrade --no-cache \
     # Resolves CVE-2021-22945, as it's not yet upgraded in upstream image

--- a/deploy/update-typescript-environments.sh
+++ b/deploy/update-typescript-environments.sh
@@ -13,14 +13,14 @@ if [ ! -f "$file" ]; then
 fi
 
 # Regex replace on the properties
-# s/{FIND THIS}/{REPLACE WITH THIS}/{FLAGS}
+# s%{FIND THIS}%{REPLACE WITH THIS}%{FLAGS}
 # These regex patterns are written so it should be able to replace even if
 # the values are set to something (sane)
 sed -i "
-    s/version: '[^']*'/version: '${BUILD_VERSION}'/g
-    s/ciGitCommit: '[^']*'/ciGitCommit: '${BUILD_GIT_COMMIT}'/g
-    s/ciBuildDate: new Date('[^']*')/ciBuildDate: new Date('${BUILD_DATE}')/g
-    s/ciBuildRef: [0-9-]*/ciBuildRef: ${BUILD_REF}/g
+    s%version: '[^']*'%version: '${BUILD_VERSION}'%g
+    s%ciGitCommit: '[^']*'%ciGitCommit: '${BUILD_GIT_COMMIT}'%g
+    s%ciBuildDate: new Date('[^']*')%ciBuildDate: new Date('${BUILD_DATE}')%g
+    s%ciBuildRef: [0-9-]*%ciBuildRef: ${BUILD_REF}%g
 " "$file"
 
 echo "$0: Updated values in: $file"


### PR DESCRIPTION
## Summary

- Changed deploy tag in `.wharf-ci.yml` to `:canary`
- Changed to use our internal Docker Hub registry caching proxy in Docker builds
- Fixed Wharf build step name in `.wharf-ci.yml`

## Motivation

Minor tweaks to make the Wharf builds work and be able to build Wharf itself.

- Inspired by https://github.com/iver-wharf/wharf-api/pull/124
- Related to https://github.com/iver-wharf/iver-wharf.github.io/issues/80