### PR TITLE
Fixed double collect-licenses in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,6 @@ ARG BUILD_REF="0"
 ARG BUILD_DATE=""
 RUN deploy/update-typescript-environments.sh src/environments/environment.prod.ts \
     && npm run build-clients \
-    && npm run collect-licenses \
     && npm run build-prod
 
 FROM nginx:1-alpine


### PR DESCRIPTION
- \[ ] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Removed duplicate `npm run collect-licenses` from Dockerfile

## Motivation

`npm run build-prod` already runs `collect-licenses`.
