### PR TITLE
Fix windows docker build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,6 @@
 
 # API guardian patch must always use LF for tests to work
 *.patch eol=lf
+
+# Handle line endings for docker scripts on Windows
+*.sh text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   as that package has not yet been updated in the upstream `nginx` Docker image.
   (#88)
 
-- Changed docker-build scripts for easier windows building. (#95)
+- Changed Dockerfile for easier windows building. (#95)
 
 ## v1.4.0 (2021-09-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   as that package has not yet been updated in the upstream `nginx` Docker image.
   (#88)
 
+- Changed docker-build scripts for easier windows building. (#95)
+
 ## v1.4.0 (2021-09-10)
 
 - Added toast message support for IETF RFC-7807 formatted error responses.

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ ARG BUILD_VERSION="local docker"
 ARG BUILD_GIT_COMMIT="HEAD"
 ARG BUILD_REF="0"
 ARG BUILD_DATE=""
-RUN deploy/update-typescript-environments.sh src/environments/environment.prod.ts \
+RUN chmod +x deploy/update-typescript-environments.sh \
+    && deploy/update-typescript-environments.sh src/environments/environment.prod.ts \
     && npm run build-clients \
     && npm run build-prod
 

--- a/deploy/update-typescript-environments.sh
+++ b/deploy/update-typescript-environments.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 file="${1:?'Environments TS file must be provided'}"
 


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

Shebang signature modified for docker runs. Had issues on docker windows.

## Motivation

This makes it easier to docker build on windows.

Also see similar changes:
- https://github.com/iver-wharf/wharf-web/pull/95
- https://github.com/iver-wharf/wharf-provider-azuredevops/pull/48
- https://github.com/iver-wharf/wharf-provider-github/pull/44
- https://github.com/iver-wharf/wharf-provider-gitlab/pull/39
- https://github.com/iver-wharf/wharf-api/pull/126