### PR TITLE
Resolve licenses module for rxjs version 6 compatability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 ## v1.5.1 (WIP)
 
 - Changed rxjs behaviour on license module to allow cross 6-7 rxjs version
-  compatability. (#96)
+  compatibility. (#96)
 
 ## v1.5.0 (2021-11-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v1.5.1 (WIP)
+
+- Changed rxjs behaviour on license module to allow cross 6-7 rxjs version
+  compatability. (#96)
+
 ## v1.5.0 (2021-11-15)
 
 - Removed per-tab titles on project details page. Title is now either

--- a/src/app/licenses/licenses.component.ts
+++ b/src/app/licenses/licenses.component.ts
@@ -18,7 +18,7 @@ export class LicensesComponent implements OnInit {
     licenseService: LicensesService,
   ) {
     licenseService.licenses$.subscribe({
-      next: licenses => this.licenses = licenses,
+      next: (licenses: License[]) => this.licenses = licenses,
       error: err => {
         console.error(err);
         if (err instanceof HttpErrorResponse) {

--- a/src/app/shared/licenses/licenses.service.ts
+++ b/src/app/shared/licenses/licenses.service.ts
@@ -3,6 +3,8 @@ import { License } from './licenses.model';
 import { HttpClient } from '@angular/common/http';
 import { BehaviorSubject } from 'rxjs';
 
+const LICENSES_URL = '/assets/licenses.json';
+
 @Injectable({
   providedIn: 'root',
 })
@@ -10,11 +12,9 @@ export class LicensesService {
 
   public licenses$: BehaviorSubject<License[]> = new BehaviorSubject<License[]>(null);
 
-  private readonly LICENSCE_URL = '/assets/licenses.json';
-
   constructor(private http: HttpClient) {
-      this.http.get<License[]>(this.LICENSCE_URL).subscribe(
-        license => this.licenses$.next(license),
+      this.http.get<License[]>(LICENSES_URL).subscribe(
+        licenses => this.licenses$.next(licenses),
       );
   }
 }

--- a/src/app/shared/licenses/licenses.service.ts
+++ b/src/app/shared/licenses/licenses.service.ts
@@ -1,16 +1,20 @@
 import { Injectable } from '@angular/core';
 import { License } from './licenses.model';
 import { HttpClient } from '@angular/common/http';
-import { shareReplay } from 'rxjs';
+import { BehaviorSubject } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
 })
 export class LicensesService {
-  licenses$ = this.http.get<License[]>('/assets/licenses.json').pipe(
-    shareReplay(),
-  );
+
+  public licenses$: BehaviorSubject<License[]> = new BehaviorSubject<License[]>(null);
+
+  private readonly LICENSCE_URL = '/assets/licenses.json';
 
   constructor(private http: HttpClient) {
+      this.http.get<License[]>(this.LICENSCE_URL).subscribe(
+        license => this.licenses$.next(license),
+      );
   }
 }


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

By replacing the `shareReplay` rxjs v7 import with an alternative rxjs v6 compatible operation we achive cross version compatability.
I would argue this is a better solution as it allows easier access to the cached value of the behaviour subject.

## Motivation

Currently the auth module has a bit of an uncertain future as to rxjs version compatability. This allows problem free compilation  of the web module in either codebase. Hopefully later we can upgrade the remote repo for the auth client such that the rxjs 7 version gets used.
