### PR TITLE
Fix overlay popup issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14549,7 +14549,8 @@
           "dependencies": {
             "ansi-regex": {
               "version": "5.0.0",
-              "resolved": "",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+              "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
               "dev": true
             },
             "strip-ansi": {
@@ -14720,7 +14721,8 @@
           "dependencies": {
             "ansi-regex": {
               "version": "5.0.0",
-              "resolved": "",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+              "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
               "dev": true
             },
             "ansi-styles": {

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,5 @@
 <wh-notification></wh-notification>
-  <div class="grid-container">
+<div class="grid-container">
   <wh-app-nav></wh-app-nav>
   <div class="wharf-container">
     <router-outlet></router-outlet>

--- a/src/app/nav/nav.component.html
+++ b/src/app/nav/nav.component.html
@@ -10,8 +10,7 @@
           {{env.version}} <i class="pi pi-question-circle"></i>
         </button>
 
-        <p-overlayPanel #versionPanel (onShow)="onOverlayShow()" (onHide)="onOverlayHide()"
-          styleClass="version-panel-container" appendTo="body">
+        <p-overlayPanel #versionPanel (onShow)="fetchServiceVersions()" styleClass="version-panel" appendTo="body">
           <ng-template pTemplate>
             <ul>
               <li>

--- a/src/app/nav/nav.component.html
+++ b/src/app/nav/nav.component.html
@@ -6,7 +6,7 @@
           <h3>WHARF</h3>
         </a>
 
-        <button #versionButton class="version-button" type="button" pButton (click)="versionPanel.toggle($event)">
+        <button class="version-button" type="button" pButton (click)="versionPanel.toggle($event)">
           {{env.version}} <i class="pi pi-question-circle"></i>
         </button>
 

--- a/src/app/nav/nav.component.html
+++ b/src/app/nav/nav.component.html
@@ -6,11 +6,12 @@
           <h3>WHARF</h3>
         </a>
 
-        <button class="version-button" type="button" pButton (click)="versionPanel.toggle($event)">
+        <button #versionButton class="version-button" type="button" pButton (click)="versionPanel.toggle($event)">
           {{env.version}} <i class="pi pi-question-circle"></i>
         </button>
 
-        <p-overlayPanel class="version-panel" #versionPanel (onShow)="fetchServiceVersions()">
+        <p-overlayPanel #versionPanel (onShow)="onOverlayShow()" (onHide)="onOverlayHide()"
+          styleClass="version-panel-container" appendTo="body">
           <ng-template pTemplate>
             <ul>
               <li>

--- a/src/app/nav/nav.component.ts
+++ b/src/app/nav/nav.component.ts
@@ -88,13 +88,6 @@ export class NavComponent implements OnInit {
     ];
   }
 
-  fetchLicenses() {
-    this.licensesService.licenses$.subscribe({
-      next: console.log,
-      error: console.error,
-    });
-  }
-
   fetchServiceVersions() {
     if (this.isFetchingVersions) {
       return;
@@ -106,6 +99,13 @@ export class NavComponent implements OnInit {
     this.updateAppVersion(ServiceName.ProviderGitHub, this.gitHubMetaService.githubVersionGet());
     this.updateAppVersion(ServiceName.ProviderGitLab, this.gitLabMetaService.gitlabVersionGet());
     this.updateAppVersion(ServiceName.ProviderAzureDevOps, this.azureDevOpsMetaService.azuredevopsVersionGet());
+  }
+
+  fetchLicenses() {
+    this.licensesService.licenses$.subscribe({
+      next: console.log,
+      error: console.error,
+    });
   }
 
   private updateAppVersion(serviceName: ServiceName, version$: Observable<VersionResponse>) {

--- a/src/app/nav/nav.component.ts
+++ b/src/app/nav/nav.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, ElementRef, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { ChangeDetectorRef, Component, OnInit } from '@angular/core';
 import { MenuItem } from 'primeng/api';
 import { environment } from 'src/environments/environment';
 import { MetaService as GitLabMetaService } from 'import-gitlab-client';
@@ -39,9 +39,7 @@ enum ServiceName {
   selector: 'wh-app-nav',
   templateUrl: './nav.component.html',
 })
-export class NavComponent implements OnInit, OnDestroy {
-  @ViewChild('versionButton') versionButton: ElementRef<HTMLButtonElement>;
-
+export class NavComponent implements OnInit {
   projectItem: MenuItem[];
   items: MenuItem[];
   documentationItem: MenuItem[];
@@ -57,7 +55,6 @@ export class NavComponent implements OnInit, OnDestroy {
   ];
 
   private isFetchingVersions = false;
-  private overlayStyleMutationObserver: MutationObserver;
 
   constructor(
     private gitLabMetaService: GitLabMetaService,
@@ -91,19 +88,6 @@ export class NavComponent implements OnInit, OnDestroy {
     ];
   }
 
-  ngOnDestroy() {
-    this.cleanupHackyFixOverlayObserver();
-  }
-
-  onOverlayShow() {
-    this.fetchServiceVersions();
-    this.hackyFixOverlayPosition();
-  }
-
-  onOverlayHide() {
-    this.cleanupHackyFixOverlayObserver();
-  }
-
   fetchLicenses() {
     this.licensesService.licenses$.subscribe({
       next: console.log,
@@ -111,7 +95,7 @@ export class NavComponent implements OnInit, OnDestroy {
     });
   }
 
-  private fetchServiceVersions() {
+  fetchServiceVersions() {
     if (this.isFetchingVersions) {
       return;
     }
@@ -153,46 +137,5 @@ export class NavComponent implements OnInit, OnDestroy {
         }
       },
     });
-  }
-
-  private hackyFixOverlayPosition() {
-    // There's a bug with PrimeNG's OverlayPanel combined with `position: fixed`
-    // where the window scroll position is always added to the `top: 123px`.
-    const panel = document.getElementsByClassName('version-panel-container')[0];
-    if (!panel) {
-      console.warn('Unable to find version overlay panel');
-      return;
-    }
-    if (!(panel instanceof HTMLDivElement)) {
-      console.warn('Expected overlay panel to be a <div>, but was not:', panel.nodeType);
-      return;
-    }
-
-    // We can't update the position here because the invalid positioning is
-    // applied after OverlayPanel.onShow is invoked:
-    // https://github.com/primefaces/primeng/blob/12.0.0/src/app/components/overlaypanel/overlaypanel.ts#L226-L228
-    this.cleanupHackyFixOverlayObserver();
-    this.overlayStyleMutationObserver = new MutationObserver(m => this.onOverlayStyleMutated(panel, m));
-    this.overlayStyleMutationObserver.observe(panel, {
-      attributes: true,
-      attributeFilter: ['style'],
-    });
-  }
-
-  private onOverlayStyleMutated(panel: HTMLDivElement, mutations: MutationRecord[]) {
-    const btn = this.versionButton.nativeElement;
-    const rect = btn.getBoundingClientRect();
-    const top = Math.floor(rect.bottom) + 'px';
-    if (panel.style.top !== top) {
-      panel.style.top = top;
-      this.cleanupHackyFixOverlayObserver(); // only need it once.
-    }
-  }
-
-  private cleanupHackyFixOverlayObserver() {
-    if (this.overlayStyleMutationObserver) {
-      this.overlayStyleMutationObserver.disconnect();
-      this.overlayStyleMutationObserver = null;
-    }
   }
 }

--- a/src/scss/nav.component.scss
+++ b/src/scss/nav.component.scss
@@ -1,7 +1,12 @@
-.version-panel-container {
+.version-panel {
+  background-color: $wharf_sidenav_menu_version_details_background_color;
+  // PrimeNG's automatic position gets messed up by `position: fixed` as it
+  // always adds the window's scroll. This overrides that.
+  top: 5.6rem !important;
+
   &.p-overlaypanel {
-    background-color: $wharf_sidenav_menu_version_details_background_color;
     position: fixed;
+
     // There's a bug with PrimeNG's OverlayPanel combined with `position: fixed`
     // where it sets `display: none`.
     // https://github.com/primefaces/primeng/issues/5311
@@ -74,12 +79,15 @@
       display: flex;
       justify-content: center;
       margin-bottom: 0;
+      margin-top: 2rem;
+      height: 2rem;
     }
 
     .version-button {
       display: block;
       margin: 0 auto;
       padding: 0.2rem 0.2rem 0.2rem 0.4rem;
+      height: 1.5rem;
       font-size: 0.8rem;
       color: $wharf_sidenav_menu_version_color;
       background-color: $wharf_sidenav_menu_version_background_color;

--- a/src/scss/nav.component.scss
+++ b/src/scss/nav.component.scss
@@ -1,3 +1,55 @@
+.version-panel-container {
+  &.p-overlaypanel {
+    background-color: $wharf_sidenav_menu_version_details_background_color;
+    position: fixed;
+    // There's a bug with PrimeNG's OverlayPanel combined with `position: fixed`
+    // where it sets `display: none`.
+    // https://github.com/primefaces/primeng/issues/5311
+    display: block !important;
+  }
+
+  ul {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .label {
+    font-size: 0.8rem;
+    color: $wharf_sidenav_menu_version_details_label_color;
+  }
+
+  .value {
+    padding-inline-start: 1rem;
+    color: $wharf_sidenav_menu_version_details_value_color;
+  }
+
+  .label,
+  .value {
+    display: block;
+    overflow-wrap: break-word;
+  }
+
+  .version-pending {
+    color: $wharf_sidenav_menu_version_remote_pending_text_color;
+
+    .p-progress-spinner {
+      width: 0.8em;
+      height: 0.8em;
+      vertical-align: baseline;
+    }
+  }
+
+  .version-error {
+    color: $wharf_sidenav_menu_version_remote_error_text_color;
+
+    .pi {
+      vertical-align: middle;
+      margin-right: 0.3rem;
+    }
+  }
+}
+
 .sidenav {
   position: fixed;
   height: 100vh;
@@ -41,53 +93,6 @@
       .pi {
         vertical-align: text-bottom;
         font-size: 1em;
-      }
-    }
-
-    .version-panel {
-      .p-overlaypanel {
-        background-color: $wharf_sidenav_menu_version_details_background_color;
-      }
-
-      ul {
-        list-style-type: none;
-        margin: 0;
-        padding: 0;
-      }
-
-      .label {
-        font-size: 0.8rem;
-        color: $wharf_sidenav_menu_version_details_label_color;
-      }
-
-      .value {
-        padding-inline-start: 1rem;
-        color: $wharf_sidenav_menu_version_details_value_color;
-      }
-
-      .label,
-      .value {
-        display: block;
-        overflow-wrap: break-word;
-      }
-
-      .version-pending {
-        color: $wharf_sidenav_menu_version_remote_pending_text_color;
-
-        .p-progress-spinner {
-          width: 0.8em;
-          height: 0.8em;
-          vertical-align: baseline;
-        }
-      }
-
-      .version-error {
-        color: $wharf_sidenav_menu_version_remote_error_text_color;
-
-        .pi {
-          vertical-align: middle;
-          margin-right: 0.3rem;
-        }
       }
     }
   }


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Fixed version overlay position and clipping issues introduced in #82 (v1.5.0) by:

  - Added  `top: 5.6rem !important` to override the buggy overlay position caused by PrimeNG when using `position: fixed`
  - Append version panel to `<body>` instead of inside the side nav to enforce it be placed above all other elements from the page content
  - Moved styling in nav.component.scss to apply to the version panel even when not inside the `.sidebar`

## Motivation

PrimeNG errornously always adds the window's scroll to the overlay's position. Our overlay is meant to target an element that has `position: fixed`, so it's not affected by window scroll. This is a bug in PrimeNG and this PR is a hacky solution to get around that. The same issue exists in the latest version of PrimeNG, v13.0.1: <https://github.com/primefaces/primeng/blob/13.0.02/src/app/components/dom/domhandler.ts#L130-L162>

In addition to this, it had started making the overlay narrower to fit inside the side nav, while the intent is for it to just be an overlay. Therefore the move to just be placed at the end of the `<body>` instead, so it's not tied to any width/height limitations, as well as being placed under some main page content (such as the build list or build log output)

Closes #90

## Preview

### Before

It's being locked to the width of the navbar:

![Screenshot from 2021-12-16 11-23-33](https://user-images.githubusercontent.com/2477952/146354597-d7dc2c16-ebdb-4eb5-a927-2740e155af55.png)

If scrolling the page, the scroll is added to the `top: ...px` CSS styling, resulting in misplacement:

![Screenshot from 2021-12-16 11-23-47](https://user-images.githubusercontent.com/2477952/146354592-0e86f745-cc17-4a38-a184-c2e6db93fdcc.png)

### After

Now even when having some page scroll, it opens correctly:

![Screenshot from 2021-12-16 11-23-06](https://user-images.githubusercontent.com/2477952/146354601-97ab2e18-5d98-41c8-ba63-1aa11818bf86.png)
