### PR TITLE
Added rfc4648 license

### DIFF
--- a/deploy/collect-licenses/licenses_override/rfc4648@1.5.0.txt
+++ b/deploy/collect-licenses/licenses_override/rfc4648@1.5.0.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) <year> <copyright holder>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.


### PR DESCRIPTION
- \[ ] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added license override for [rfc4648.js](https://github.com/swansontec/rfc4648.js)

## Motivation

The package doesn't have a LICENSE file, but instead states that it uses MIT license in it's package.json. This adds the license text so shut up the license checker

Build logs:

```
Failed to fetch remote LICENSE file for rfc4648@1.5.0 due to none of the files gave OK response: [ 'LICENSE', 'LICENSE.md', 'LICENSE.txt' ]
Cannot use license texts from README files, as their content is error-prone: [
  {
    package: 'rfc4648@1.5.0',
    repo: 'https://github.com/swansontec/rfc4648.js',
    licenses: 'MIT'
  }
]
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! wharf@0.0.0 build-prod: `node deploy/collect-licenses/collect-licenses.js && ng build -c production`
npm ERR! Exit status 1
```