### PR TITLE
Release v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v1.5.1 (WIP)
+## v1.5.1 (2022-01-10)
 
 - Fixed version panel misplacement on scrollable pages and being locked to the
   width of the side nav bar, a bug introduced in v1.5.0 by #82. (#97)


### PR DESCRIPTION
- \[x] I've updated the `(WIP)` tag to today's date in `CHANGELOG.md`
- \[x] I've added the `release` label to this PR

## Changes

- Fixed version panel misplacement on scrollable pages and being locked to the width of the side nav bar, a bug introduced in v1.5.0 by #82. (#97)

- Security: Changed version of `jsprim` to v1.4.2 and `json-schema` to v0.4.0 to resolve CVE-2021-3918. (#100)

## Actions after merge

Follow the step-by-step guide found here:
<https://iver-wharf.github.io/#/development/releasing-a-new-version?id=merging-a-release-pr>
