### PR TITLE
Update json-schema to 0.4.0 for CVE-2021-3918

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Fixed version panel misplacement on scrollable pages and being locked to the
   width of the side nav bar, a bug introduced in v1.5.0 by #82. (#97)
 
+- Security: Changed version of `jsprim` to v1.4.2 and `json-schema` to v0.4.0
+  to resolve CVE-2021-3918. (#100)
+
 ## v1.5.0 (2021-11-15)
 
 - Removed per-tab titles on project details page. Title is now either

--- a/package-lock.json
+++ b/package-lock.json
@@ -10248,9 +10248,9 @@
       "dev": true
     },
     "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true
     },
     "json-schema-traverse": {
@@ -10308,14 +10308,14 @@
       "dev": true
     },
     "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -69,6 +69,8 @@
     "eslint-plugin-prefer-arrow": "1.2.3",
     "jasmine-core": "^3.8.0",
     "jasmine-spec-reporter": "^7.0.0",
+    "json-schema": "^0.4.0",
+    "jsprim": "^1.4.2",
     "karma": "^6.3.4",
     "karma-chrome-launcher": "~3.1.0",
     "karma-coverage-istanbul-reporter": "~3.0.2",


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Updated to `jsprim@1.4.2`
- Updated to `json-schema@0.4.0`

## Motivation

The jsprim update was needed as `jsprim@1.4.1` depends on `json-schema@0.2.3`, while `jsprim@1.4.2` depends on the fixed `json-schema@0.4.0`.

Dependabot failed to do an automatic update, as it didn't want to update jsprim for us (<https://github.com/iver-wharf/wharf-web/security/dependabot/package-lock.json/json-schema/open/update-logs/170945279>). This PR does that manually instead.