### PR TITLE
Fixed lint-fix Makefile targets ordering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 	docker docker-run serve \
 	clients-force clients \
 	lint lint-ng lint-md lint-scss \
-	lint-fix lint-ng-fix lint-md-fix lint-scss-fix
+	lint-fix lint-fix-ng lint-fix-md lint-fix-scss
 
 commit = $(shell git rev-parse HEAD)
 version = latest
@@ -56,22 +56,22 @@ dist/import-azuredevops-client:
 
 lint: lint-ng lint-md lint-scss
 
-lint-fix: lint-ng-fix lint-md-fix lint-scss-fix
+lint-fix: lint-fix-ng lint-fix-md lint-fix-scss
 
 lint-ng:
 	npx ng lint
 
-lint-ng-fix:
+lint-fix-ng:
 	npx ng lint --fix
 
 lint-md:
 	remark . .github
 
-lint-md-fix:
+lint-fix-md:
 	remark . .github -o
 
 lint-scss:
 	stylelint 'src/**/*.scss'
 
-lint-scss-fix:
+lint-fix-scss:
 	stylelint 'src/**/*.scss' --fix

--- a/README.md
+++ b/README.md
@@ -138,9 +138,9 @@ code. These can be fixed by running the following:
 ```sh
 make lint-fix
 
-make lint-ng-fix # Only fix Angular/TypeScript lint errors
-make lint-scss-fix # Only fix SCSS lint errors
-make lint-md-fix # Only fix Markdown lint errors
+make lint-fix-ng # Only fix Angular/TypeScript lint errors
+make lint-fix-scss # Only fix SCSS lint errors
+make lint-fix-md # Only fix Markdown lint errors
 ```
 
 A lot of other errors, such as "member should be camelCased", is not fixable by


### PR DESCRIPTION
## Summary

- Renamed Makefile targets from `lint-{lang}-fix` to `lint-fix-{lang}` to stay consistent with the README.md

## Motivation

Having the lang part last makes most sense to me as it lets the most specific part be last in the string, sort of like reverse domain names.
