### PR TITLE
Fixed no project ID sent when refreshing project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   which includes upgrade of `node-fetch` from v2.6.5 to v3.2.0, fixing
   [CVE-2022-0235](https://nvd.nist.gov/vuln/detail/CVE-2022-0235). (#110)
 
+- Fixed no project ID being sent to the provider APIs when refreshing, which
+  was resulting in attempting to import the project anew instead. (#113)
+
 ## v1.5.1 (2022-01-10)
 
 - Fixed version panel misplacement on scrollable pages and being locked to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   which includes upgrade of `node-fetch` from v2.6.5 to v3.2.0, fixing
   [CVE-2022-0235](https://nvd.nist.gov/vuln/detail/CVE-2022-0235). (#110)
 
-- Fixed no project ID being sent to the provider APIs when refreshing, which
+- Fixed project ID not being sent to the provider APIs when refreshing, which
   was resulting in attempting to import the project anew instead. (#113)
 
 ## v1.5.1 (2022-01-10)

--- a/src/app/providers/providers.service.ts
+++ b/src/app/providers/providers.service.ts
@@ -34,6 +34,7 @@ export class ProvidersService {
     switch (project.provider.name) {
       case ProviderType.GitLab.toLowerCase():
         return this.gitlabService.gitlabPost({
+          projectId: project.projectId,
           url: project.provider.url,
           tokenId: project.provider.tokenId,
           group: project.groupName,
@@ -42,6 +43,7 @@ export class ProvidersService {
         });
       case ProviderType.GitHub.toLowerCase():
         return this.gitHubService.githubPost({
+          projectId: project.projectId,
           url: project.provider.url,
           tokenId: project.provider.tokenId,
           group: project.groupName,
@@ -50,6 +52,7 @@ export class ProvidersService {
         });
       case ProviderType.AzureDevOps.toLowerCase():
         return this.azureDevOpsService.azuredevopsPost({
+          projectId: project.projectId,
           url: project.provider.url,
           tokenId: project.provider.tokenId,
           group: project.groupName,


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

Set the `projectId` field for the request body in the `refreshProject` function.

## Motivation

Before wharf-api v5.0.0 the importing code in the providers looked a bit different and they didn't really mind if the ID was sent or not, the code path it took was a bit longer but it still worked pretty much the same.

This is no longer the case and needs to be fixed.