### PR TITLE
Added engine field to action modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 ## v1.6.0 (WIP)
 
-- Adds the ability to login. While logged in this will forward the OIDC
+- Added the ability to login. While logged in this will forward the OIDC
   access token to the backend such that a secure user access control is
   established. (#70)
 
@@ -38,6 +38,9 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Fixed project ID not being sent to the provider APIs when refreshing, which
   was resulting in attempting to import the project anew instead. (#113)
+
+- Added field for changing execution engine used in a build via the
+  "RUN ALL OPTIONS" modal. (#122)
 
 ## v1.5.1 (2022-01-10)
 

--- a/src/app/models/main-project.model.ts
+++ b/src/app/models/main-project.model.ts
@@ -3,18 +3,18 @@ import { ProjectBuild } from './project-build.model';
 import { ProjectAction } from './project-action.model';
 
 export class WharfProject implements ResponseProject {
-    avatarUrl?: string;
-    branches?: ResponseBranch[];
-    buildDefinition?: string;
-    buildHistory?: ResponseBuild[];
-    description?: string;
-    gitUrl?: string;
-    groupName?: string;
-    name?: string;
-    projectId?: number;
-    provider?: ResponseProvider;
-    providerId?: number;
-    tokenId?: number;
-    build?: ProjectBuild;
-    actions?: ProjectAction[];
+  avatarUrl?: string;
+  branches?: ResponseBranch[];
+  buildDefinition?: string;
+  buildHistory?: ResponseBuild[];
+  description?: string;
+  gitUrl?: string;
+  groupName?: string;
+  name?: string;
+  projectId?: number;
+  provider?: ResponseProvider;
+  providerId?: number;
+  tokenId?: number;
+  build?: ProjectBuild;
+  actions?: ProjectAction[];
 }

--- a/src/app/projects/actions-modal/actions-modal.component.html
+++ b/src/app/projects/actions-modal/actions-modal.component.html
@@ -66,5 +66,48 @@
         <div *ngSwitchDefault>Field not recognized. Type: {{input.type}}</div>
       </div>
     </div>
+    <div class="form-control">
+      <div [ngSwitch]="this.engines?.length">
+        <h5>
+          <label>Execution engine</label>
+          <span *ngSwitchCase="undefined">: Loading...</span>
+          <span *ngSwitchCase="0">: <i>None available or error loading.</i></span>
+          <span *ngSwitchCase="1">:
+            <span [pTooltip]="engines[0].url" tooltipPosition="top">
+              <strong class="engine-name">{{engines[0].name}}</strong>
+              <span>(id: <span class="engine-id">{{engines[0].id}}</span>)</span>
+            </span>
+          </span>
+          <i class="var-info-icon pi pi-info-circle"
+            pTooltip='Execution engine is where the code will be executed. Wharf traditionally supports Jenkins and wharf-cmd.
+            This field is only changeable when there are multiple execution engines configured in wharf-api.'
+            tooltipPosition="top"
+          ></i>
+        </h5>
+        <div *ngSwitchDefault>
+          <p-dropdown
+            [options]="this.engines"
+            optionLabel="name"
+            optionValue="id"
+            formControlName="engine">
+            <ng-template let-engine pTemplate="selectedItem">
+              <div>
+                <span class="engine-name">{{engine.name}}</span>
+                <small>(id: <span class="engine-id">{{engine.id}}</span>)</small>
+              </div>
+            </ng-template>
+            <ng-template let-engine pTemplate="item">
+              <div>
+                <strong class="engine-name">{{engine.name}}</strong>
+                <small>(id: <span class="engine-id">{{engine.id}}</span>)</small>
+              </div>
+              <div>
+                <small class="engine-url">{{engine.url}}</small>
+              </div>
+            </ng-template>
+          </p-dropdown>
+        </div>
+      </div>
+    </div>
   </form>
 </ng-template>

--- a/src/scss/actions-modal.component.scss
+++ b/src/scss/actions-modal.component.scss
@@ -10,10 +10,20 @@
   .var-info-icon {
     vertical-align: bottom;
     color: $wharf_palette_cloud_grey;
+    margin-left: 0.3rem;
 
     &:hover {
       color: inherit;
     }
+  }
+
+  .engine-name {
+    margin-right: 0.3em;
+  }
+
+  .engine-id {
+    font-family: $wharf_code_font_family;
+    font-size: 90%;
   }
 
   .action-buttons {


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs
- \[x] Wait for #121 to be merged.

## Summary

- Added engine field when starting a new build.

## Motivation

Exposes the `?engine=` query parameter when starting a build via the GUI.

## Preview

With no engines configured, or if the wharf-api doesn't support engines (such as if it's below v5.1.0):


![Screenshot from 2022-03-07 16-34-20](https://user-images.githubusercontent.com/2477952/157065670-fb88fe39-3a7c-4b1a-82a9-0f0dc30d4dd8.png)

With only 1 engine configured:


![Screenshot from 2022-03-07 16-34-31](https://user-images.githubusercontent.com/2477952/157065667-6057b1c0-af3f-4d12-91a0-1f45055388b4.png)

With more than 1 engine configured:

![Screenshot from 2022-03-07 16-33-51](https://user-images.githubusercontent.com/2477952/157065672-56f774f5-cde5-4b48-9d9c-d76fb6c4c9ff.png)
