### PR TITLE
Fix CVE-2021-22945

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,8 @@ ARG REG=docker.io
 FROM ${REG}/library/nginx:1-alpine
 
 RUN apk add --upgrade --no-cache \
-    # Resolves CVE-2021-22945, as it's not yet upgraded in upstream image
-    curl>7.78.0 \
-    libcurl>7.78.0
+    # Resolves CVE-2022-1271, as it's not yet upgraded in upstream image
+    'xz-libs>=5.2.5-r1'
 
 COPY --from=build /usr/src/app/dist/wharf /usr/share/nginx/html
 COPY ./deploy/nginx.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
## Summary

- Added manual upgrade of xz-libs to 5.2.5-r1 (or beyond)

## Motivation

CVE-2022-1271 was not fixed in upstream nginx image yet.

```console
$ docker save nginx:1-alpine -o nginx.tar
Copying blob 4fc242d58285 done
Copying blob be9057e6dae4 done
Copying blob c0b09410617a done
Copying blob d63b53686463 done
Copying blob 8df6b63c60d4 done
Copying blob b991c80c3ef2 done
Copying config 51696c87e7 done
Writing manifest to image destination
Storing signatures

$ trivy i -i ../nginx.tar
2022-04-14T15:48:56.653+0200	INFO	Detected OS: alpine
2022-04-14T15:48:56.653+0200	WARN	This OS version is not on the EOL list: alpine 3.15
2022-04-14T15:48:56.653+0200	INFO	Detecting Alpine vulnerabilities...
2022-04-14T15:48:56.656+0200	INFO	Number of language-specific files: 0
2022-04-14T15:48:56.656+0200	WARN	This OS version is no longer supported by the distribution: alpine 3.15.4
2022-04-14T15:48:56.656+0200	WARN	The vulnerability detection may be insufficient because security updates are not provided

../nginx.tar (alpine 3.15.4)
============================
Total: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 1, CRITICAL: 0)

+---------+------------------+----------+-------------------+---------------+--------------------------------------+
| LIBRARY | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |                TITLE                 |
+---------+------------------+----------+-------------------+---------------+--------------------------------------+
| xz-libs | CVE-2022-1271    | HIGH     | 5.2.5-r0          | 5.2.5-r1      | gzip: arbitrary-file-write           |
|         |                  |          |                   |               | vulnerability                        |
|         |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2022-1271 |
+---------+------------------+----------+-------------------+---------------+--------------------------------------+
```
