### PR TITLE
Fixed CVE's via deps update in Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,11 +111,11 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Security: Changed version of Alpine packages in Dockerfile to resolve CVEs:
 
-  - `xz-libs` to v5.2.5-r1 to resolve CVE-2021-3918 (#129)
+  - `xz-libs` &ge; v5.2.5-r1 to resolve CVE-2021-3918 (#129)
 
-  - `freetype` to 2.11.1-r1 to resolve CVE-2022-27404 (#139)
+  - `freetype` &ge; 2.11.1-r1 to resolve CVE-2022-27404 (#139)
 
-  - `curl` & `libcurl` to 7.80.0-r1 to resolve CVE-2022-22576, CVE-2022-27774,
+  - `curl` & `libcurl` &ge; 7.80.0-r1 to resolve CVE-2022-22576, CVE-2022-27774,
     CVE-2022-27776, and CVE-2022-27775 (#139)
 
 ## v1.5.1 (2022-01-10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,15 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Changed to require Node 16 or later due to new `package-lock.json` format
   changes since NPM 7.0.0, which comes with Node 15.0.0 or later. (#130)
 
+- Security: Changed version of Alpine packages in Dockerfile to resolve CVEs:
+
+  - `xz-libs` to v5.2.5-r1 to resolve CVE-2021-3918 (#129)
+
+  - `freetype` to 2.11.1-r1 to resolve CVE-2022-27404 (#139)
+
+  - `curl` & `libcurl` to 7.80.0-r1 to resolve CVE-2022-22576, CVE-2022-27774,
+    CVE-2022-27776, and CVE-2022-27775 (#139)
+
 ## v1.5.1 (2022-01-10)
 
 - Fixed version panel misplacement on scrollable pages and being locked to the

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,11 @@ FROM ${REG}/library/nginx:1-alpine
 
 RUN apk add --upgrade --no-cache \
     # Resolves CVE-2022-1271, as it's not yet upgraded in upstream image
-    'xz-libs>=5.2.5-r1'
+    'xz-libs>=5.2.5-r1' \
+    # Resolves CVE-2022-27404
+    'freetype>=2.11.1-r1' \
+    # Resolves CVE-2022-22576, CVE-2022-27774, CVE-2022-27775, & CVE-2022-27776
+    'curl>=7.80.0-r1'
 
 COPY --from=build /usr/src/app/dist/wharf /usr/share/nginx/html
 COPY ./deploy/nginx.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Updated `freetype`
- Updated `curl`

## Motivation

The base image haven't resolved these issues yet.

The xz-libs CVE was fixes in #129, but there has popped up two more recently:

```console
$ trivy i -i nginx-1-alpine.tar
2022-05-09T10:17:50.002+0200	INFO	Detected OS: alpine
2022-05-09T10:17:50.002+0200	WARN	This OS version is not on the EOL list: alpine 3.15
2022-05-09T10:17:50.002+0200	INFO	Detecting Alpine vulnerabilities...
2022-05-09T10:17:50.006+0200	INFO	Number of language-specific files: 0
2022-05-09T10:17:50.006+0200	WARN	This OS version is no longer supported by the distribution: alpine 3.15.4
2022-05-09T10:17:50.006+0200	WARN	The vulnerability detection may be insufficient because security updates are not provided

nginx-1-alpine.tar (alpine 3.15.4)
==================================
Total: 10 (UNKNOWN: 0, LOW: 2, MEDIUM: 6, HIGH: 1, CRITICAL: 1)

+----------+------------------+----------+-------------------+---------------+---------------------------------------+
| LIBRARY  | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |                 TITLE                 |
+----------+------------------+----------+-------------------+---------------+---------------------------------------+
| curl     | CVE-2022-22576   | MEDIUM   | 7.80.0-r0         | 7.80.0-r1     | curl: OAUTH2 bearer bypass            |
|          |                  |          |                   |               | in connection re-use                  |
|          |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2022-22576 |
+          +------------------+          +                   +               +---------------------------------------+
|          | CVE-2022-27774   |          |                   |               | curl: credential leak on redirect     |
|          |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2022-27774 |
+          +------------------+          +                   +               +---------------------------------------+
|          | CVE-2022-27776   |          |                   |               | curl: auth/cookie leak on redirect    |
|          |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2022-27776 |
+          +------------------+----------+                   +               +---------------------------------------+
|          | CVE-2022-27775   | LOW      |                   |               | curl: bad local IPv6 connection reuse |
|          |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2022-27775 |
+----------+------------------+----------+-------------------+---------------+---------------------------------------+
| freetype | CVE-2022-27404   | CRITICAL | 2.11.1-r0         | 2.11.1-r1     | FreeType: Buffer Overflow             |
|          |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2022-27404 |
+----------+------------------+----------+-------------------+---------------+---------------------------------------+
| libcurl  | CVE-2022-22576   | MEDIUM   | 7.80.0-r0         | 7.80.0-r1     | curl: OAUTH2 bearer bypass            |
|          |                  |          |                   |               | in connection re-use                  |
|          |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2022-22576 |
+          +------------------+          +                   +               +---------------------------------------+
|          | CVE-2022-27774   |          |                   |               | curl: credential leak on redirect     |
|          |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2022-27774 |
+          +------------------+          +                   +               +---------------------------------------+
|          | CVE-2022-27776   |          |                   |               | curl: auth/cookie leak on redirect    |
|          |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2022-27776 |
+          +------------------+----------+                   +               +---------------------------------------+
|          | CVE-2022-27775   | LOW      |                   |               | curl: bad local IPv6 connection reuse |
|          |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2022-27775 |
+----------+------------------+----------+-------------------+---------------+---------------------------------------+
| xz-libs  | CVE-2022-1271    | HIGH     | 5.2.5-r0          | 5.2.5-r1      | gzip: arbitrary-file-write            |
|          |                  |          |                   |               | vulnerability                         |
|          |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2022-1271  |
+----------+------------------+----------+-------------------+---------------+---------------------------------------+
```
