### PR TITLE
Release v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v1.6.0 (2022-05-09)
+## v1.6.0 (2022-05-10)
 
 - Added the ability to login. While logged in this will forward the OIDC
   access token to the backend such that a secure user access control is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,8 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   - `curl` & `libcurl` &ge; 7.80.0-r1 to resolve CVE-2022-22576, CVE-2022-27774,
     CVE-2022-27776, and CVE-2022-27775 (#139)
 
+- Fixed PrimeIcons icon names since upgrade from v4 to v5 in #125. (#141)
+
 ## v1.5.1 (2022-01-10)
 
 - Fixed version panel misplacement on scrollable pages and being locked to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v1.6.0 (WIP)
+## v1.6.0 (2022-05-09)
 
 - Added the ability to login. While logged in this will forward the OIDC
   access token to the backend such that a secure user access control is


### PR DESCRIPTION
- \[x] I've updated the `(WIP)` tag to today's date in `CHANGELOG.md`
- \[x] I've added the `release` label to this PR
- \[x] Wait for #142 to be merged.

## Changes

- Added the ability to login. While logged in this will forward the OIDC access token to the backend such that a secure user access control is established. This is only performed when the following config value is set: (#70, #137, #138, #142)

  ```json
  {
    "oidcConfig": {
      "enabled": true
    }
  }
  ```

- Changed function calls and type names to match the regenerated rest clients using: (#91)

  - `wharf-api` from v4.1.0 to v5.0.0.
  - `wharf-provider-azuredevops` from v1.2.0-rc to v2.0.1.
  - `wharf-provider-github` from v2.0.0-rc to v2.0.0.
  - `wharf-provider-gitlab` from v1.2.0-rc to v1.3.0.

- Added test results failed/skipped/passed numbers to each build in a project's build list. (#53)

- Added test result details, showing test messages and per-artifact test results, to the build details page. (#53)

- Security: Changed version of `wharf-collect-licenses` from v1.0.0 to v2.0.0, which includes upgrade of `node-fetch` from v2.6.5 to v3.2.0, fixing [CVE-2022-0235](https://nvd.nist.gov/vuln/detail/CVE-2022-0235). (#110)

- Fixed project ID not being sent to the provider APIs when refreshing, which was resulting in attempting to import the project anew instead. (#113)

- Added field for changing execution engine used in a build via the "RUN ALL OPTIONS" modal. (#122)

- Removed unused configs, specified in `assets/config.json`, and `"Environment"` object in `assets/config.json` and inlined their configs instead, as well as renamed `Name` to `name` and `IsProduction` to `production`: (#127)

  ```diff
  --- a/assets/config.json
  +++ b/assets/config.json
   {
  -  "Environment": {
  -    "Name": "lorem-ipsum",
  -    "IsProduction": true
  -  },
  +  "name": "lorem-ipsum",
  +  "production": true,

  -  "UpdateLatency": 20000,
  -  "UpdateFrequency": 30000,

     "BackendUrls": {
       "Api": "/api",
       "Gitlab": "/import",
       "Github": "/import",
       "AzureDevops": "/import",
     }
   }
  ```

  Backward compatibtility is added, so the `Environment.Name` and `Environment.IsProduction` inside `assets/config.json` still work.

- Deprecated all PascalCased fields inside `assets/config.json` in favor of camelCased variants. Wharf-web performs automatic translation, but please migrate your configs to camelCase as soon as possible, such as: (#127)

  ```diff
  --- a/assets/config.json
  +++ b/assets/config.json
   {
  -  "BackendUrls": {
  -    "Api": "/api",
  -    "Gitlab": "/import",
  -    "Github": "/import",
  -    "AzureDevops": "/import",
  -  }
  +  "backendUrls": {
  +    "api": "/api",
  +    "gitlab": "/import",
  +    "github": "/import",
  +    "azureDevops": "/import",
  +  }
   }
  ```

- Changed version of dependencies:

  - `@angular/*` from v12.1.1 to v13.3.2 (#125)
  - `eslint` from v7.30.0 to v8.12.0 (#125)
  - `ng-packagr` from v12.1.1 to v13.3.0 (#125)
  - `primeicons` from v4.1.0 to v5.0.0 (#125)
  - `primeng` from v12.0.0 to v13.3.3 (#125)
  - `rxjs` from v7.2.0 to v7.5.5 (#125)
  - `typescript` from v4.3.5 to v4.6.3 (#125)

- Changed to require Node 16 or later due to new `package-lock.json` format changes since NPM 7.0.0, which comes with Node 15.0.0 or later. (#130)

- Security: Changed version of Alpine packages in Dockerfile to resolve CVEs:

  - `xz-libs` &ge; v5.2.5-r1 to resolve CVE-2021-3918 (#129)

  - `freetype` &ge; 2.11.1-r1 to resolve CVE-2022-27404 (#139)

  - `curl` & `libcurl` &ge; 7.80.0-r1 to resolve CVE-2022-22576, CVE-2022-27774,
    CVE-2022-27776, and CVE-2022-27775 (#139)

- Fixed PrimeIcons icon names since upgrade from v4 to v5 in #125. (#141)

## Actions after merge

Follow the step-by-step guide found here:
<https://iver-wharf.github.io/#/development/releasing-a-new-version?id=merging-a-release-pr>
