### PR TITLE
Fixed favorites button

### DIFF
--- a/src/app/projects/project-favorite/project-favorite-button.component.ts
+++ b/src/app/projects/project-favorite/project-favorite-button.component.ts
@@ -26,8 +26,8 @@ export class ProjectFavoriteButtonComponent {
 
   getClass() {
     if (this.localStorageProjectsService.projectIsFavorite(this.projectId)) {
-      return 'pi pi-star';
+      return 'pi pi-star-fill';
     }
-    return 'pi pi-star-o';
+    return 'pi pi-star';
   }
 }


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Fixed wrong star icon for favorites

## Motivation

Courtesy of @Alexamakans for the research! It was just an icon change between PrimeIcons versions.

Closes #132
