### PR TITLE
Use EventSourcePolyfill instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Added the ability to login. While logged in this will forward the OIDC
   access token to the backend such that a secure user access control is
   established. This is only performed when the following config value
-  is set: (#70, #137, #138)
+  is set: (#70, #137, #138, #142)
 
   ```json
   {


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Changed to using EventSourcePolyfill if OIDC is enabled, that does support setting headers

## Motivation

Want to get this merged into our 1.6.0 release: #140

Got 403 Unauthorized on the log stream endpoint `GET /api/build/{buildId}/stream`

This was because the built-in EventSource doesn't support setting headers, just like with websockets... However through a little digging I found that there are plenty of polyfill packages available. One of which was already added to the repo! Someone had a foresight :)

**Edit:** Did a git blame, and the `ng-event-source` package comes from our GitLab repo before we moved to GitHub. Was added by Marek 2 years ago, but he forgot to use `EventSourcePolyfill` instead of `EventSource`. Fun hunt :)