### PR TITLE
Fixed azuredevops config loading

### DIFF
--- a/projects/projects.module.ts
+++ b/projects/projects.module.ts
@@ -1,4 +1,4 @@
-import { NgModule, Provider, Type } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { ApiModule, Configuration } from 'api-client';
 import { ApiModule as AzureApiModule, Configuration as AzureConfiguration } from 'import-azuredevops-client';
 import { ApiModule as GitHubApiModule, Configuration as GitHubConfiguration } from 'import-github-client';
@@ -45,7 +45,7 @@ export class ConfiguredGitLabApiModule { }
   imports: [{
     ngModule: AzureApiModule,
     providers: [{
-      provide: AzureApiModule,
+      provide: AzureConfiguration,
       useFactory: () => new AzureConfiguration({ basePath: environment.backendUrls.azureDevopsImport })
     }],
   }],


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Fixed Azure DevOps config registration

## Motivation

It couldn't talk to wharf-provisioner-azuredevops because it was always using the default base URL.
