### PR TITLE
Fixed log streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v1.6.2 (WIP)
+
+- Fixed log not streaming. (#147)
+
 ## v1.6.1 (2022-05-10)
 
 - Fixed Azure DevOps configuration loading. (#143)

--- a/src/app/builds/build-details/build-details.component.ts
+++ b/src/app/builds/build-details/build-details.component.ts
@@ -46,11 +46,17 @@ export class BuildDetailsComponent implements OnInit, OnDestroy, AfterViewChecke
     if (this.buildStatus === BuildStatus.Scheduling || this.buildStatus === BuildStatus.Running) {
       if (!this.source) {
         this.source = this.openEventSourceStream();
-        this.source.addEventListener('message', this.listener);
+        this.source.addEventListener('message', this.listener.bind(this));
       }
     } else {
+      console.log('Skipping logs streaming because the build is not running:', {
+        buildId: this.buildId,
+        statusId: this.buildStatus,
+        status: this.build.status,
+      });
       if (this.source) {
         this.source.close();
+        this.source = null;
       }
 
       if (!(this.buildStatus in BuildStatus)) {


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added missing `.bind()` on method passed to log handler

## Motivation

In Go it's binding automatically :(

Closes #146
