### PR TITLE
Fix click on stage specific dropdown run options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Fixed log not streaming. (#147)
 
+- Fixed an issue where input was being ignored on a dropdown for
+  selecting a specific stage build stage to run. (#148)
+
 ## v1.6.1 (2022-05-10)
 
 - Fixed Azure DevOps configuration loading. (#143)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,10 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 ## v1.6.2 (WIP)
 
-- Fixed log not streaming. (#147)
+- Fixed an issue where input was being ignored on a dropdown for 
+  selecting a specific build stage to run. (#148)
 
-- Fixed an issue where input was being ignored on a dropdown for
-  selecting a specific stage build stage to run. (#148)
+- Fixed log not streaming. (#147)
 
 ## v1.6.1 (2022-05-10)
 

--- a/src/app/projects/actions-modal/actions-modal.component.ts
+++ b/src/app/projects/actions-modal/actions-modal.component.ts
@@ -122,7 +122,7 @@ export class ActionsModalComponent implements OnInit, OnDestroy {
       });
     }
     // eslint-disable-next-line no-underscore-dangle
-    this.initialFormState.branch = this.editedProjectInstance.branches?.find(o => o._default);
+    this.initialFormState.branch = this.editedProjectInstance.branches?.find(o => o._default) ?? '';
     this.initialFormState.environment =
       this.editedProjectInstance.build.environments[1] // 1 to skip the first noEnvironment
       || this.projectUtilsService.noEnvironment;
@@ -131,6 +131,7 @@ export class ActionsModalComponent implements OnInit, OnDestroy {
     inputsGroup.environment = new FormControl('');
     inputsGroup.engine = new FormControl('');
     this.actionsFormGroup = new FormGroup(inputsGroup);
+    this.initialFormState.engine = this.initialFormState.engine ?? '';
     this.actionsFormGroup.setValue(this.initialFormState);
   }
 
@@ -147,7 +148,7 @@ export class ActionsModalComponent implements OnInit, OnDestroy {
   }
 
   private populateFieldsOfEditableProject() {
-    if (this.project.build.inputs) {
+    if (this.project?.build?.inputs) {
       Object.values(this.project.build.inputs).map((input, index) => {
         const inputField: InputField = {
           default: input.default,
@@ -160,7 +161,7 @@ export class ActionsModalComponent implements OnInit, OnDestroy {
         }
       });
     }
-    if (this.project.build.environments) {
+    if (this.project?.build?.environments) {
       this.populateEnvironments();
     }
   }

--- a/src/app/projects/actions-modal/actions-modal.component.ts
+++ b/src/app/projects/actions-modal/actions-modal.component.ts
@@ -122,7 +122,7 @@ export class ActionsModalComponent implements OnInit, OnDestroy {
       });
     }
     // eslint-disable-next-line no-underscore-dangle
-    this.initialFormState.branch = this.editedProjectInstance.branches.find(o => o._default);
+    this.initialFormState.branch = this.editedProjectInstance.branches?.find(o => o._default);
     this.initialFormState.environment =
       this.editedProjectInstance.build.environments[1] // 1 to skip the first noEnvironment
       || this.projectUtilsService.noEnvironment;

--- a/src/app/projects/project-details/project-details.component.html
+++ b/src/app/projects/project-details/project-details.component.html
@@ -32,7 +32,7 @@
           <ng-template pTemplate="side-header-override">
             <p-splitButton *ngIf="project.actions" class="button-container"
               label="{{projectUtilsService.runAllActionName}}"
-              [model]="projectUtilsService.getActionsMenuItems(project)"
+              [model]="buildStageMenuItems"
               (onClick)="projectUtilsService.openActions(projectUtilsService.runAllActionName,project)">
             </p-splitButton>
           </ng-template>

--- a/src/app/projects/project-details/project-details.component.ts
+++ b/src/app/projects/project-details/project-details.component.ts
@@ -9,6 +9,7 @@ import { ActionsModalStore } from '../actions-modal/actions-modal.service';
 import { ProjectService } from 'api-client';
 import { ActivatedRoute } from '@angular/router';
 import { Title } from '@angular/platform-browser';
+import { MenuItem } from 'primeng/api/menuitem';
 
 @Component({
   selector: 'wh-project-details',
@@ -23,6 +24,7 @@ export class ProjectDetailsComponent implements OnInit {
   buildsTotalCount = 0;
   rowsCount = 10;
   destroyed$ = new Subject<void>();
+  buildStageMenuItems: MenuItem[];
 
   constructor(
     public projectUtilsService: ProjectUtilsService,
@@ -47,6 +49,7 @@ export class ProjectDetailsComponent implements OnInit {
     const projectId = this.route.snapshot.paramMap.get('projectId');
     this.projectService.getProject(Number(projectId)).subscribe(project => {
       this.project = project;
+      this.buildStageMenuItems = this.projectUtilsService.getActionsMenuItems(this.project);
       // Temporary initialization to render table, after that loadBuildsLazy handles builds fetching
       this.project.buildHistory = [];
       this.updateTitle();

--- a/src/app/projects/project-list/project-list-item.component.html
+++ b/src/app/projects/project-list/project-list-item.component.html
@@ -1,7 +1,7 @@
-<td class="col-name url-link" [routerLink]="['/project', project.projectId]"><a [routerLink]="['/project', project.projectId]">{{project.name}}</a></td>
-<td class="col-group" [routerLink]="['/project', project.projectId]">{{project.groupName}}</td>
-<td class="col-provider" [routerLink]="['/project', project.projectId]">{{providerHostname}}</td>
-<td class="col-status" [routerLink]="['/project', project.projectId]"><span class="not-available">N/A</span></td>
+<td class="col-name url-link"><a [routerLink]="['/project', project.projectId]">{{project.name}}</a></td>
+<td class="col-group">{{project.groupName}}</td>
+<td class="col-provider">{{providerHostname}}</td>
+<td class="col-status"><span class="not-available">N/A</span></td>
 <td class="col-actions">
   <p-splitButton
     [disabled]="!menuItems.length"

--- a/src/app/projects/project-list/project-list-item.component.html
+++ b/src/app/projects/project-list/project-list-item.component.html
@@ -5,8 +5,7 @@
 <td class="col-actions">
   <p-splitButton *ngIf="projectUtilsService.getActionsMenuItems(project).length > 0"
     label="{{projectUtilsService.runAllActionName}}" [model]="projectUtilsService.getActionsMenuItems(project)"
-    (onClick)="projectUtilsService.openActions(projectUtilsService.runAllActionName, project)"
-    (click)="$event.stopPropagation()">
+    (onClick)="projectUtilsService.openActions(projectUtilsService.runAllActionName, project)">
   </p-splitButton>
 </td>
 <td class="col-quickactions">

--- a/src/app/projects/project-list/project-list-item.component.html
+++ b/src/app/projects/project-list/project-list-item.component.html
@@ -4,8 +4,7 @@
 <td class="col-status"><span class="not-available">N/A</span></td>
 <td class="col-actions">
   <p-splitButton
-    label="{{projectUtilsService.runAllActionName}}" [model]="projectUtilsService.getActionsMenuItems(project)"
-    (onClick)="projectUtilsService.openActions(projectUtilsService.runAllActionName, project)">
+    label="{{projectUtilsService.runAllActionName}}" [model]="menuItems">
   </p-splitButton>
 </td>
 <td class="col-quickactions">

--- a/src/app/projects/project-list/project-list-item.component.html
+++ b/src/app/projects/project-list/project-list-item.component.html
@@ -3,9 +3,11 @@
 <td class="col-provider">{{providerHostname}}</td>
 <td class="col-status"><span class="not-available">N/A</span></td>
 <td class="col-actions">
-  <p-splitButton
-    label="{{projectUtilsService.runAllActionName}}" [model]="menuItems">
-  </p-splitButton>
+  <p-splitButton *ngIf="menuItems.length"
+    label="{{projectUtilsService.runAllActionName}}"
+    [model]="menuItems"
+    (onClick)="projectUtilsService.openActions(projectUtilsService.runAllActionName, project)"
+  ></p-splitButton>
 </td>
 <td class="col-quickactions">
   <wh-project-refresh-icon (refreshed)="refreshed.emit($event)" [project]="project"></wh-project-refresh-icon>

--- a/src/app/projects/project-list/project-list-item.component.html
+++ b/src/app/projects/project-list/project-list-item.component.html
@@ -3,7 +3,9 @@
 <td class="col-provider" [routerLink]="['/project', project.projectId]">{{providerHostname}}</td>
 <td class="col-status" [routerLink]="['/project', project.projectId]"><span class="not-available">N/A</span></td>
 <td class="col-actions">
-  <p-splitButton *ngIf="menuItems.length"
+  <p-splitButton
+    [disabled]="!menuItems.length"
+    [pTooltip]="noValidBuildStepsTooltip"
     label="{{projectUtilsService.runAllActionName}}"
     [model]="menuItems"
     (onClick)="projectUtilsService.openActions(projectUtilsService.runAllActionName, project)"

--- a/src/app/projects/project-list/project-list-item.component.html
+++ b/src/app/projects/project-list/project-list-item.component.html
@@ -1,4 +1,4 @@
-<td class="col-name">{{project.name}}</td>
+<td class="col-name url-link"><a [routerLink]="['/project', project.projectId]">{{project.name}}</a></td>
 <td class="col-group">{{project.groupName}}</td>
 <td class="col-provider">{{providerHostname}}</td>
 <td class="col-status"><span class="not-available">N/A</span></td>

--- a/src/app/projects/project-list/project-list-item.component.html
+++ b/src/app/projects/project-list/project-list-item.component.html
@@ -1,7 +1,7 @@
-<td class="col-name url-link"><a [routerLink]="['/project', project.projectId]">{{project.name}}</a></td>
-<td class="col-group">{{project.groupName}}</td>
-<td class="col-provider">{{providerHostname}}</td>
-<td class="col-status"><span class="not-available">N/A</span></td>
+<td class="col-name url-link" [routerLink]="['/project', project.projectId]"><a [routerLink]="['/project', project.projectId]">{{project.name}}</a></td>
+<td class="col-group" [routerLink]="['/project', project.projectId]">{{project.groupName}}</td>
+<td class="col-provider" [routerLink]="['/project', project.projectId]">{{providerHostname}}</td>
+<td class="col-status" [routerLink]="['/project', project.projectId]"><span class="not-available">N/A</span></td>
 <td class="col-actions">
   <p-splitButton *ngIf="menuItems.length"
     label="{{projectUtilsService.runAllActionName}}"

--- a/src/app/projects/project-list/project-list-item.component.html
+++ b/src/app/projects/project-list/project-list-item.component.html
@@ -3,7 +3,7 @@
 <td class="col-provider">{{providerHostname}}</td>
 <td class="col-status"><span class="not-available">N/A</span></td>
 <td class="col-actions">
-  <p-splitButton *ngIf="projectUtilsService.getActionsMenuItems(project).length > 0"
+  <p-splitButton
     label="{{projectUtilsService.runAllActionName}}" [model]="projectUtilsService.getActionsMenuItems(project)"
     (onClick)="projectUtilsService.openActions(projectUtilsService.runAllActionName, project)">
   </p-splitButton>

--- a/src/app/projects/project-list/project-list-item.component.html
+++ b/src/app/projects/project-list/project-list-item.component.html
@@ -5,7 +5,7 @@
 <td class="col-actions">
   <p-splitButton
     [disabled]="!menuItems.length"
-    [pTooltip]="noValidBuildStepsTooltip"
+    [pTooltip]="noStagesTooltip"
     label="{{projectUtilsService.runAllActionName}}"
     [model]="menuItems"
     (onClick)="projectUtilsService.openActions(projectUtilsService.runAllActionName, project)"

--- a/src/app/projects/project-list/project-list-item.component.ts
+++ b/src/app/projects/project-list/project-list-item.component.ts
@@ -27,6 +27,7 @@ export class ProjectListItemComponent implements OnInit, OnChanges {
   isRefreshAnimationPlaying: boolean;
   providerHostname: string;
   menuItems: MenuItem[];
+  noValidBuildStepsTooltip;
 
   constructor(
     public localStorageProjectsService: LocalStorageProjectsService,
@@ -35,6 +36,9 @@ export class ProjectListItemComponent implements OnInit, OnChanges {
 
   ngOnInit() {
     this.menuItems = this.projectUtilsService.getActionsMenuItems(this.project);
+    if (!this.menuItems.length) {
+      this.noValidBuildStepsTooltip = 'There are no valid build steps for this project!';
+    }
   }
 
   ngOnChanges(changes: NgChanges<ProjectListItemComponent>): void {

--- a/src/app/projects/project-list/project-list-item.component.ts
+++ b/src/app/projects/project-list/project-list-item.component.ts
@@ -27,7 +27,7 @@ export class ProjectListItemComponent implements OnInit, OnChanges {
   isRefreshAnimationPlaying: boolean;
   providerHostname: string;
   menuItems: MenuItem[];
-  noValidBuildStepsTooltip;
+  noStagesTooltip;
 
   constructor(
     public localStorageProjectsService: LocalStorageProjectsService,
@@ -37,7 +37,7 @@ export class ProjectListItemComponent implements OnInit, OnChanges {
   ngOnInit() {
     this.menuItems = this.projectUtilsService.getActionsMenuItems(this.project);
     if (!this.menuItems.length) {
-      this.noValidBuildStepsTooltip = 'There are no valid build steps for this project!';
+      this.noStagesTooltip = 'There are no stages for this project!';
     }
   }
 

--- a/src/app/projects/project-list/project-list-item.component.ts
+++ b/src/app/projects/project-list/project-list-item.component.ts
@@ -1,16 +1,24 @@
-import { Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+} from '@angular/core';
 import { WharfProject } from 'src/app/models/main-project.model';
 import { NgChanges } from 'src/app/shared/util/ngchanges';
 import { LocalStorageProjectsService } from '../local-storage-projects.service';
 import { ProjectFavoriteClickEvent } from '../project-favorite/project-favorite-button.component';
 import { ProjectRefreshedEvent } from '../project-refresh';
 import { ProjectUtilsService } from '../project-utils.service';
+import { MenuItem } from 'primeng/api/menuitem';
 
 @Component({
   selector: 'wh-project-list-item',
   templateUrl: './project-list-item.component.html',
 })
-export class ProjectListItemComponent implements OnChanges {
+export class ProjectListItemComponent implements OnInit, OnChanges {
   @Input() project: WharfProject;
 
   @Output() refreshed = new EventEmitter<ProjectRefreshedEvent>();
@@ -18,11 +26,16 @@ export class ProjectListItemComponent implements OnChanges {
 
   isRefreshAnimationPlaying: boolean;
   providerHostname: string;
+  menuItems: MenuItem[];
 
   constructor(
     public localStorageProjectsService: LocalStorageProjectsService,
     public projectUtilsService: ProjectUtilsService,
   ) { }
+
+  ngOnInit() {
+    this.menuItems = this.projectUtilsService.getActionsMenuItems(this.project);
+  }
 
   ngOnChanges(changes: NgChanges<ProjectListItemComponent>): void {
     if (changes.project && this.project?.provider?.url) {

--- a/src/app/projects/project-list/project-list.component.html
+++ b/src/app/projects/project-list/project-list.component.html
@@ -43,7 +43,7 @@
           (refreshed)="onProjectRefreshed($event)"
           (favoriteClick)="initFavoriteProjects()"
           role="button"
-          (click)="onProjectRowClicked($event, project)"></wh-project-list-item>
+        ></wh-project-list-item>
       </ng-template>
     </p-table>
   </ng-template>

--- a/src/app/projects/project-list/project-list.component.html
+++ b/src/app/projects/project-list/project-list.component.html
@@ -42,7 +42,6 @@
           [project]="project"
           (refreshed)="onProjectRefreshed($event)"
           (favoriteClick)="initFavoriteProjects()"
-          role="button"
         ></wh-project-list-item>
       </ng-template>
     </p-table>

--- a/src/app/projects/project-list/project-list.component.ts
+++ b/src/app/projects/project-list/project-list.component.ts
@@ -61,15 +61,6 @@ export class ProjectListComponent implements OnInit {
     });
   }
 
-  onProjectRowClicked(event, project: WharfProject) {
-    // Hack to avoid navigation on event bubbling from child buttons.
-    const targetClassName: string = event.target.className;
-    if (targetClassName.includes('p-button')) {
-      return;
-    }
-    this.router.navigate(['/project', project.projectId]);
-  }
-
   onProjectRefreshed(event: ProjectRefreshedEvent) {
     this.replaceProject(event.projectId);
   }

--- a/src/app/projects/project-list/project-list.component.ts
+++ b/src/app/projects/project-list/project-list.component.ts
@@ -61,7 +61,12 @@ export class ProjectListComponent implements OnInit {
     });
   }
 
-  onProjectRowClicked(event: MouseEvent, project: WharfProject) {
+  onProjectRowClicked(event, project: WharfProject) {
+    // Hack to avoid navigation on event bubbling from child buttons.
+    const targetClassName: string = event.target.className;
+    if (targetClassName.includes('p-button')) {
+      return;
+    }
     this.router.navigate(['/project', project.projectId]);
   }
 

--- a/src/app/projects/project-utils.service.ts
+++ b/src/app/projects/project-utils.service.ts
@@ -23,7 +23,7 @@ export class ProjectUtilsService {
     if (proj.build != null) {
       const actions: MenuItem[] = Object.keys(proj.build)
         .filter(x => !this.actionsExcludedElements.includes(x))
-        .map(x => ({ label: x, command: () => this.openActions(x, proj.build) }));
+        .map<MenuItem>(x => ({ label: x, value: x, command: () => this.openActions(x, proj.build) }));
       return actions;
     }
     return [];

--- a/src/app/projects/project-utils.service.ts
+++ b/src/app/projects/project-utils.service.ts
@@ -23,7 +23,7 @@ export class ProjectUtilsService {
     if (proj.build != null) {
       const actions: MenuItem[] = Object.keys(proj.build)
         .filter(x => !this.actionsExcludedElements.includes(x))
-        .map<MenuItem>(x => ({ label: x, value: x, command: () => this.openActions(x, proj.build) }));
+        .map<MenuItem>(x => ({ label: x, value: x, command: () => this.openActions(x, proj) }));
       return actions;
     }
     return [];
@@ -33,7 +33,7 @@ export class ProjectUtilsService {
     return [...new Set<string>(Object.keys(proj.build.environments || {}))];
   }
 
-  openActions(label, proj) {
+  openActions(label, proj: WharfProject) {
     this.actionsModalStore.openModal(
       {
         project: proj,

--- a/src/app/projects/project-utils.service.ts
+++ b/src/app/projects/project-utils.service.ts
@@ -21,24 +21,10 @@ export class ProjectUtilsService {
 
   getActionsMenuItems(proj: WharfProject): MenuItem[] {
     if (proj.build != null) {
-      proj.actions = [];
-      return Object.keys(proj.build)
+      const actions: MenuItem[] = Object.keys(proj.build)
         .filter(x => !this.actionsExcludedElements.includes(x))
-        .map((x) => {
-          proj.actions.push({ label: x, value: x });
-          return { label: x, command: () => this.openActions(x, proj) };
-        });
-    }
-    return [];
-  }
-
-  getActionsEnvironments(proj: WharfProject): string[] {
-    if (proj.build != null) {
-      const actions = Object.keys(proj.build || {})
-        .filter(x => !this.actionsExcludedElements.includes(x))
-        .map(x => proj.build[x].environments);
-
-      return [...new Set<string>([].concat.apply([], actions))];
+        .map(x => ({ label: x, command: () => this.openActions(x, proj.build) }));
+      return actions;
     }
     return [];
   }

--- a/src/scss/project-list-item.component.scss
+++ b/src/scss/project-list-item.component.scss
@@ -134,10 +134,6 @@ body .p-datatable .p-datatable-tbody > wh-project-list-item {
 
   &:hover {
     background-color: $wharf_table_row_hover_background_color;
-
-    &[role="button"] {
-      cursor: pointer;
-    }
   }
 
   > td {


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

This reworks some 'project-list-item' & 'project-details' such that the menuitem model is created once on init instead of `ngOnChanges`. 
Removed a few redundant artifacts in the project-utils service call that generates the menuitems.

~~This all resulted in a large number of null pointer runtime errors originating from the `actions-modal.component.ts` as i dont know what this is supposed to do i have nullchecked where nessascery to ensure an error free run. There is likely still a need to review what functionality is missing or not working as expected in the actions-modal component.~~

Added a few nullchecks on the actions-modal component in regards to the creation of form elements where optional fields from `WharfProject` are missing.

## Motivation
This solves and issue where clicking on an item in a dropdown menu has no action.
https://github.com/iver-wharf/wharf-web/issues/145

Closes https://github.com/iver-wharf/wharf-web/issues/145
Closes https://github.com/iver-wharf/wharf-web/issues/102