### PR TITLE
Release v1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v1.6.2 (WIP)
+## v1.6.2 (2022-05-12)
 
 - Fixed an issue where input was being ignored on a dropdown for 
   selecting a specific build stage to run. (#148)


### PR DESCRIPTION
- \[x] I've updated the `(WIP)` tag to today's date in `CHANGELOG.md`
- \[x] I've added the `release` label to this PR

## Changes

- Fixed an issue where input was being ignored on a dropdown for selecting a specific build stage to run. (#148)

- Fixed log not streaming. (#147)


## Actions after merge

Follow the step-by-step guide found here:
<https://iver-wharf.github.io/#/development/releasing-a-new-version?id=merging-a-release-pr>
